### PR TITLE
[SEP-269] Improved observabilty in audit table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,6 +156,7 @@ data/
 tmp/
 sql/scratchpad.sql
 .secret/
+docs/
 
 # dbt
 dbt/sepa_analytics/target/

--- a/src/sepa_pipeline/loaders/bronze_audit.py
+++ b/src/sepa_pipeline/loaders/bronze_audit.py
@@ -31,8 +31,28 @@ AUDIT_SCHEMA = pa.schema(
         pa.field("raw_zip_path", pa.string()),
         pa.field("parquet_path", pa.string()),
         pa.field("ingested_at", pa.timestamp("us")),
+        # Silver processing stats — only set for table_type='silver_precios'
+        pa.field("validation_dropped", pa.int64()),
+        pa.field("integrity_dropped", pa.int64()),
+        pa.field("negative_price_count", pa.int64()),
+        pa.field("silver_loaded", pa.int64()),
     ]
 )
+
+# Columns added in schema v2 — used to evolve existing tables
+_SILVER_STAT_COLUMNS = {
+    "validation_dropped",
+    "integrity_dropped",
+    "negative_price_count",
+    "silver_loaded",
+}
+
+# Maps internal ParquetLoader table keys → audit table_type values
+_BRONZE_TABLE_TYPE_NAMES = {
+    "comercio":   "bronze_comercio",
+    "sucursales": "bronze_sucursales",
+    "productos":  "bronze_productos",
+}
 
 
 class BronzeAuditWriter:
@@ -61,6 +81,20 @@ class BronzeAuditWriter:
                 ):
                     table._io._thread_locals.get_fs_cached.cache_clear()
 
+    def _evolve_schema_if_needed(self, table: object) -> None:
+        """Add silver stat columns to existing tables that predate schema v2."""
+        from pyiceberg.types import LongType
+
+        existing = {field.name for field in table.schema().fields}
+        missing = _SILVER_STAT_COLUMNS - existing
+        if not missing:
+            return
+
+        logger.info(f"[AUDIT] Evolving schema: adding columns {sorted(missing)}")
+        with table.update_schema() as update:
+            for name in sorted(missing):
+                update.add_column(name, LongType())
+
     def _ensure_table(self) -> object | None:
         if not self.catalog:
             return None
@@ -68,6 +102,7 @@ class BronzeAuditWriter:
         try:
             table = self.catalog.load_table(self._TABLE_ID)
             self._fix_io_endpoint(table)
+            self._evolve_schema_if_needed(table)
             return table
         except NoSuchTableError:
             logger.info(f"[AUDIT] Creating {self._TABLE_ID}...")
@@ -104,7 +139,8 @@ class BronzeAuditWriter:
 
         now = datetime.now()
         rows = []
-        for table_type, stats in audit_data.items():
+        for internal_key, stats in audit_data.items():
+            table_type = _BRONZE_TABLE_TYPE_NAMES.get(internal_key, f"bronze_{internal_key}")
             rows.append(
                 {
                     "fecha_vigencia": fecha_vigencia,
@@ -113,14 +149,76 @@ class BronzeAuditWriter:
                     "csv_column_count": stats.get("csv_cols", 0),
                     "parquet_row_count": stats.get("parquet_rows", 0),
                     "raw_zip_path": raw_zip_path,
-                    "parquet_path": f"{parquet_prefix}/{table_type}.parquet",
+                    "parquet_path": f"{parquet_prefix}/{internal_key}.parquet",
                     "ingested_at": now,
+                    # Silver stats are null for bronze-layer rows
+                    "validation_dropped": None,
+                    "integrity_dropped": None,
+                    "negative_price_count": None,
+                    "silver_loaded": None,
                 }
             )
 
-        df = pl.DataFrame(rows)
+        df = pl.DataFrame(rows, schema_overrides={
+            "validation_dropped": pl.Int64,
+            "integrity_dropped": pl.Int64,
+            "negative_price_count": pl.Int64,
+            "silver_loaded": pl.Int64,
+        })
         arrow_table = df.to_arrow().cast(AUDIT_SCHEMA)
 
         logger.info(f"[AUDIT] Writing {len(rows)} audit rows for {fecha_vigencia}")
         table.append(arrow_table)
         logger.info("[AUDIT] Audit write complete")
+
+    def write_silver_stats(
+        self,
+        fecha_vigencia: date,
+        drop_stats: Dict[str, int],
+        parquet_prefix: str,
+    ) -> None:
+        """
+        Append a single 'silver_precios' audit row with per-drop-reason counts.
+
+        Args:
+            fecha_vigencia: The business date.
+            drop_stats: Output from SEPAValidator.get_drop_stats().
+            parquet_prefix: S3 prefix for the bronze parquet files (for lineage).
+        """
+        table = self._ensure_table()
+        if table is None:
+            logger.warning("[AUDIT] Skipping silver audit write (catalog not available)")
+            return
+
+        row = {
+            "fecha_vigencia": fecha_vigencia,
+            "table_type": "silver_precios",
+            "csv_row_count": 0,
+            "csv_column_count": 0,
+            "parquet_row_count": 0,
+            "raw_zip_path": "",
+            "parquet_path": f"{parquet_prefix}/productos.parquet",
+            "ingested_at": datetime.now(),
+            "validation_dropped": drop_stats.get("validation_dropped", 0),
+            "integrity_dropped": drop_stats.get("integrity_dropped", 0),
+            "negative_price_count": drop_stats.get("negative_price_count", 0),
+            "silver_loaded": drop_stats.get("silver_loaded", 0),
+        }
+
+        df = pl.DataFrame([row], schema_overrides={
+            "validation_dropped": pl.Int64,
+            "integrity_dropped": pl.Int64,
+            "negative_price_count": pl.Int64,
+            "silver_loaded": pl.Int64,
+        })
+        arrow_table = df.to_arrow().cast(AUDIT_SCHEMA)
+
+        logger.info(
+            f"[AUDIT] Silver stats for {fecha_vigencia}: "
+            f"loaded={row['silver_loaded']:,}, "
+            f"validation_dropped={row['validation_dropped']:,}, "
+            f"integrity_dropped={row['integrity_dropped']:,}, "
+            f"negative_price_count={row['negative_price_count']:,}"
+        )
+        table.append(arrow_table)
+        logger.info("[AUDIT] Silver audit write complete")

--- a/src/sepa_pipeline/pipeline.py
+++ b/src/sepa_pipeline/pipeline.py
@@ -106,6 +106,7 @@ def process_daily_data(
     logger.info(f"Starting SEPA pipeline for {target_date} | Targets: {targets}")
 
     parquet_loader = ParquetLoader(config)
+    audit_writer = BronzeAuditWriter(config)
 
     # --- Step 1–2: Ensure bronze data exists ---
     has_parquet = parquet_loader.exists(target_date)
@@ -142,7 +143,6 @@ def process_daily_data(
             # Build parquet + audit
             audit_data = parquet_loader.build(all_csv_paths, target_date)
 
-            audit_writer = BronzeAuditWriter(config)
             audit_writer.write(
                 fecha_vigencia=target_date,
                 audit_data=audit_data,
@@ -240,9 +240,21 @@ def process_daily_data(
 
         total_loaded += chunk.height
 
+    drop_stats = validator.get_drop_stats()
+    drop_stats["silver_loaded"] = total_loaded
+
     logger.info(
         f"Pipeline completed for {target_date} | "
-        f"Products: {total_loaded:,} rows"
+        f"Products: {total_loaded:,} rows | "
+        f"Dropped — validation: {drop_stats['validation_dropped']:,}, "
+        f"integrity: {drop_stats['integrity_dropped']:,}, "
+        f"negative_price: {drop_stats['negative_price_count']:,}"
+    )
+
+    audit_writer.write_silver_stats(
+        fecha_vigencia=target_date,
+        drop_stats=drop_stats,
+        parquet_prefix=parquet_loader._parquet_prefix(target_date),
     )
 
 

--- a/src/sepa_pipeline/validator.py
+++ b/src/sepa_pipeline/validator.py
@@ -51,6 +51,23 @@ class SEPAValidator:
         "tienda fisica",
     }
 
+    def __init__(self) -> None:
+        self._drops: dict[str, int] = {
+            "validation_dropped": 0,
+            "integrity_dropped": 0,
+            "negative_price_count": 0,
+            "silver_loaded": 0,
+        }
+
+    def get_drop_stats(self) -> dict[str, int]:
+        """Return accumulated drop counts since last reset."""
+        return dict(self._drops)
+
+    def reset_drop_stats(self) -> None:
+        """Reset all drop counters (call between dates in backfill runs)."""
+        for key in self._drops:
+            self._drops[key] = 0
+
     @staticmethod
     def _read_csv(path: str, schema: dict) -> pl.DataFrame:
         """
@@ -328,8 +345,7 @@ class SEPAValidator:
 
         return df
 
-    @staticmethod
-    def validate_productos(df: pl.DataFrame) -> pl.DataFrame:
+    def validate_productos(self, df: pl.DataFrame) -> pl.DataFrame:
         """Validate productos.csv schema and data (soft validation)."""
         required_cols = list(get_schema_dict("productos").keys())
 
@@ -393,27 +409,27 @@ class SEPAValidator:
             & pl.col("productos_descripcion").is_not_null()
         )
         after = df.height
-        if after < before:
+        dropped = before - after
+        if dropped > 0:
             logger.warning(
-                f"validate_productos: filtered out {before - after}"
+                f"validate_productos: filtered out {dropped}"
                 " rows missing essential fields after soft-cast"
             )
+        self._drops["validation_dropped"] += dropped
 
-        # Filter non-positive prices but keep rows with price <= 0 only
-        #  as logs (they will be excluded from precio load)
-        negatives = df.filter(pl.col("productos_precio_lista") <= 0)
-        neg_count = negatives.height
+        # Count non-positive prices (kept in DF; excluded from precios fact load)
+        neg_count = df.filter(pl.col("productos_precio_lista") <= 0).height
         if neg_count > 0:
             logger.warning(
                 f"validate_productos: {neg_count} rows"
-                " with non-positive price will be filtered for precios load"
-                " (kept in products DF for audit)"
+                " with non-positive price (kept in batch, excluded from precios fact)"
             )
+        self._drops["negative_price_count"] += neg_count
 
         return df
 
-    @staticmethod
     def validate_referential_integrity(
+        self,
         df_comercios: pl.DataFrame,
         df_sucursales: pl.DataFrame,
         df_productos: pl.DataFrame,
@@ -490,11 +506,13 @@ class SEPAValidator:
                     " dropping them to enforce integrity."
                 )
                 # Filter out orphaned productos
+                before_integrity = df_productos.height
                 df_productos = df_productos.join(
                     sucursal_full_keys,
                     on=["id_comercio", "id_bandera", "id_sucursal"],
                     how="semi",
                 )
+                self._drops["integrity_dropped"] += before_integrity - df_productos.height
         else:
             logger.debug("No products/sucursal keys to compare (one side empty)")
 


### PR DESCRIPTION
## Summary
This PR enhances the SEPA pipeline's observability by implementing granular tracking of row drops during the validation and Silver loading stages. It addresses the "unexplained" row gap by surfacing exactly where and why data is filtered out before reaching the analytical layer.

## Changes

### 1. Validation Tracking (`src/sepa_pipeline/validator.py`)
- Added internal counters to `SEPAValidator` for four specific metrics:
    - `validation_dropped`: Rows missing essential keys or failing basic schema checks.
    - `integrity_dropped`: Rows dropped due to missing referential integrity (e.g., productos referencing non-existent sucursales).
    - `negative_price_count`: Rows containing non-positive prices (currently tracked but not filtered).
    - `silver_loaded`: Total rows successfully materialized in Silver.
- Methods `get_drop_stats()` and `reset_drop_stats()` allow the orchestrator to collect batch-level results.

### 2. Audit Table Evolution (`src/sepa_pipeline/loaders/bronze_audit.py`)
- **Automated Schema Evolution**: The `BronzeAuditWriter` now uses PyIceberg's `update_schema()` to automatically add missing columns (`validation_dropped`, `integrity_dropped`, `negative_prices_dropped`, `silver_loaded`) to the existing `sepa.bronze_audit` table without requiring a full rebuild.
- **Silver Metadata Integration**: Added `write_silver_stats()` to record a single `table_type='silver_precios'` row per ingestion date, providing a summary of the load quality.
- **Namespace Normalization**: Introduced `_BRONZE_TABLE_TYPE_NAMES` to map internal keys to prefixed names in the audit table for better clarity.

### 3. Pipeline Orchestration (`src/sepa_pipeline/pipeline.py`)
- The `audit_writer` is now initialized unconditionally to ensure metrics are captured even if Bronze Parquet already exists.
- After the batch processing loop, the pipeline collects accumulated stats, logs a detailed breakdown to the console, and persists the results to the Iceberg audit layer.

### 4. Chore
- Updated `.gitignore` to exclude the internal `docs/` directory.

**Closes:** #21