### PR TITLE
 [SEP-276] Shopping agent workflow: research/formatter split, SSE validation, MCP SQL fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,7 @@ dbt/.user.yml
 
 # agent specific
 agent/prompt.py
+.Rproj.user
+.positai
+
+.zed/

--- a/agent/api/__init__.py
+++ b/agent/api/__init__.py
@@ -1,0 +1,1 @@
+"""Agent API sub-package — FastAPI HTTP layer for the SEPA Operations Agent."""

--- a/agent/api/app.py
+++ b/agent/api/app.py
@@ -1,0 +1,99 @@
+"""FastAPI application for the SEPA Agent API.
+
+Start the server::
+
+    uv run uvicorn agent.api.app:app --host 0.0.0.0 --port 8000 --reload
+"""
+
+import logging
+import os
+import time
+from contextlib import asynccontextmanager
+from typing import AsyncGenerator
+
+from dotenv import load_dotenv
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from agent.api.routes import router
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Lifespan
+# ---------------------------------------------------------------------------
+
+_start_time: float = 0.0
+
+
+def get_uptime() -> float:
+    """Seconds since the server started."""
+    return time.monotonic() - _start_time
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+    """Initialize the ADK runtime on startup; clean up on shutdown."""
+    global _start_time
+    _start_time = time.monotonic()
+
+    # Load agent env before build_runtime so env vars are available.
+    from agent.sepa_agent import _load_agent_env, build_runtime
+
+    _load_agent_env()
+    load_dotenv()  # also load root .env for MINIO_* etc.
+
+    logger.info("Initializing ADK agent runtime...")
+    build_runtime()
+    logger.info("Agent runtime ready.")
+
+    yield
+
+    logger.info("Shutting down Agent API.")
+
+
+# ---------------------------------------------------------------------------
+# App factory
+# ---------------------------------------------------------------------------
+
+app = FastAPI(
+    title="SEPA Agent API",
+    description="HTTP API for the SEPA Operations Agent (Google ADK).",
+    version="0.1.0",
+    lifespan=lifespan,
+)
+
+# ---------------------------------------------------------------------------
+# CORS
+# ---------------------------------------------------------------------------
+
+_default_origins = [
+    "*",
+    "http://localhost:5173",
+    "http://localhost:3000",
+    "http://localhost:4321",
+    "http://127.0.0.1:5173",
+    "http://127.0.0.1:3000",
+]
+
+_cors_origins_raw = os.getenv("API_CORS_ORIGINS", "")
+cors_origins: list[str] = (
+    [o.strip() for o in _cors_origins_raw.split(",") if o.strip()]
+    if _cors_origins_raw
+    else _default_origins
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[] if "*" in cors_origins else cors_origins,
+    allow_origin_regex=r".*" if "*" in cors_origins else None,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+app.include_router(router)

--- a/agent/api/cli.py
+++ b/agent/api/cli.py
@@ -1,0 +1,27 @@
+"""CLI entry point for ``sepa-api`` (see pyproject.toml [project.scripts]).
+
+Usage::
+
+    sepa-api          # starts on 0.0.0.0:8000
+    sepa-api --port 9000
+"""
+
+import os
+
+
+def main() -> None:
+    """Launch the Agent API via uvicorn."""
+    import uvicorn
+
+    port = int(os.getenv("API_PORT", "8000"))
+    uvicorn.run(
+        "agent.api.app:app",
+        host="0.0.0.0",
+        port=port,
+        reload=False,
+        log_level="info",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/agent/api/routes.py
+++ b/agent/api/routes.py
@@ -1,0 +1,170 @@
+"""Agent API routes — streaming SSE, synchronous chat, and session management."""
+
+import json
+import logging
+import uuid
+from collections.abc import AsyncGenerator
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import StreamingResponse
+
+from agent.api.schemas import ChatRequest, ChatResponse, HealthResponse
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Health
+# ---------------------------------------------------------------------------
+
+
+@router.get("/health", response_model=HealthResponse)
+async def health() -> HealthResponse:
+    """Basic health-check. Returns agent status and uptime."""
+    from agent.api.app import get_uptime
+    from agent.sepa_agent import LOCAL_ENABLED, root_agent
+
+    model_name = "local" if LOCAL_ENABLED else "gemini-2.5-flash"
+    agent_name = root_agent.name if root_agent else "not initialized"
+
+    return HealthResponse(
+        status="ok" if root_agent else "initializing",
+        uptime_seconds=round(get_uptime(), 2),
+        agent_name=agent_name,
+        model=model_name,
+    )
+
+
+# ---------------------------------------------------------------------------
+# SSE streaming
+# ---------------------------------------------------------------------------
+
+
+@router.post("/api/agent/stream")
+async def stream_agent_response(req: ChatRequest) -> StreamingResponse:
+    """Stream agent events as Server-Sent Events (SSE).
+
+    Each event is a JSON object on a ``data:`` line.  The stream ends with
+    ``data: [DONE]``.
+
+    Event types: progress, tool_call, tool_result, final, error.
+    """
+    from agent.sepa_agent import arun_prompt_stream
+
+    session_id = req.session_id or str(uuid.uuid4())
+
+    async def event_generator() -> AsyncGenerator[str, None]:
+        try:
+            async for event_dict in arun_prompt_stream(
+                req.prompt,
+                user_id=req.user_id,
+                session_id=session_id,
+            ):
+                # Include session_id so the frontend can track it.
+                event_dict["session_id"] = session_id
+                payload = json.dumps(event_dict, ensure_ascii=False)
+                yield f"data: {payload}\n\n"
+        except Exception as exc:
+            logger.exception("Error during agent streaming")
+            error_payload = json.dumps(
+                {
+                    "type": "error",
+                    "content": str(exc),
+                    "session_id": session_id,
+                }
+            )
+            yield f"data: {error_payload}\n\n"
+        finally:
+            yield "data: [DONE]\n\n"
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Non-streaming chat (convenience / testing)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/api/agent/chat", response_model=ChatResponse)
+async def chat(req: ChatRequest) -> ChatResponse:
+    """Non-streaming chat endpoint. Returns the agent's final answer."""
+    from agent.sepa_agent import arun_prompt_stream
+
+    session_id = req.session_id or str(uuid.uuid4())
+    final_text = ""
+
+    try:
+        async for event_dict in arun_prompt_stream(
+            req.prompt,
+            user_id=req.user_id,
+            session_id=session_id,
+        ):
+            if event_dict.get("type") == "final":
+                final_text = event_dict.get("content", "")
+    except Exception as exc:
+        logger.exception("Error during agent chat")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    return ChatResponse(
+        response=final_text,
+        session_id=session_id,
+        user_id=req.user_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Session management
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/agent/sessions/{user_id}")
+async def list_sessions(user_id: str) -> dict:
+    """List known session IDs for a user.
+
+    Note: InMemorySessionService does not expose a ``list_sessions`` method,
+    so this is a best-effort stub that returns the sessions the service
+    knows about.  A DB-backed service will provide full support.
+    """
+    from agent.sepa_agent import APP_NAME, _session_service
+
+    if _session_service is None:
+        raise HTTPException(status_code=503, detail="Session service not ready")
+
+    # InMemorySessionService stores sessions in a nested dict:
+    #   _sessions[app_name][user_id] -> {session_id: Session}
+    sessions_map = getattr(_session_service, "_sessions", {})
+    user_sessions = sessions_map.get(APP_NAME, {}).get(user_id, {})
+    session_ids = list(user_sessions.keys())
+
+    return {"user_id": user_id, "sessions": session_ids}
+
+
+@router.delete("/api/agent/sessions/{user_id}/{session_id}")
+async def delete_session(user_id: str, session_id: str) -> dict:
+    """Delete / reset a specific session.
+
+    InMemorySessionService does not have a delete method, so we remove
+    the session dict entry directly.
+    """
+    from agent.sepa_agent import APP_NAME, _session_service
+
+    if _session_service is None:
+        raise HTTPException(status_code=503, detail="Session service not ready")
+
+    sessions_map = getattr(_session_service, "_sessions", {})
+    user_sessions = sessions_map.get(APP_NAME, {}).get(user_id, {})
+
+    if session_id not in user_sessions:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    del user_sessions[session_id]
+    return {"deleted": True, "session_id": session_id}

--- a/agent/api/schemas.py
+++ b/agent/api/schemas.py
@@ -1,0 +1,78 @@
+"""Pydantic request/response models for the Agent API."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class ChatRequest(BaseModel):
+    """Incoming chat message from the frontend."""
+
+    prompt: str = Field(..., min_length=1, max_length=4000)
+    user_id: str = Field(default="web-user")
+    session_id: str | None = Field(
+        default=None,
+        description="If None, auto-generates a UUID on the server side.",
+    )
+
+
+class ChatResponse(BaseModel):
+    """Non-streaming response returned by POST /api/agent/chat."""
+
+    response: str
+    session_id: str
+    user_id: str
+
+
+class HealthResponse(BaseModel):
+    """Response for GET /health."""
+
+    status: str
+    uptime_seconds: float
+    agent_name: str
+    model: str
+
+
+class SSEEvent(BaseModel):
+    """Single event emitted over the SSE stream.
+
+    Types:
+        progress   – agent is working / intermediate status
+        tool_call  – agent invoked an MCP tool
+        tool_result – tool returned a result
+        final      – agent's final answer
+        error      – something went wrong
+    """
+
+    type: Literal["progress", "tool_call", "tool_result", "final", "error"]
+    content: str = ""
+    tool: str | None = None
+    args: dict[str, Any] | None = None
+
+# Smart List feature
+
+class Item(BaseModel):
+    name: str
+    price: float
+    description: str
+    quantity: int
+
+class Stores(BaseModel):
+    name: str
+    items: list[Item]
+
+class ShoppingList(BaseModel):
+    project_name: str = Field()
+    message: str = Field(..., min_length=1, max_length=4096)
+    total_estimate: float
+    savings: float
+    stores: list[Stores]
+
+class SmartListResponse(BaseModel):
+    """Response returned by the agent for SmartList, combining chat info and the shopping list."""
+    response: str
+    session_id: str
+    user_id: str
+    shopping_list: ShoppingList

--- a/agent/api/schemas.py
+++ b/agent/api/schemas.py
@@ -50,29 +50,25 @@ class SSEEvent(BaseModel):
     content: str = ""
     tool: str | None = None
     args: dict[str, Any] | None = None
+    data: dict[str, Any] | None = None
+
 
 # Smart List feature
-
 class Item(BaseModel):
-    name: str
-    price: float
-    description: str
-    quantity: int
+    name: str = Field(..., min_length=1)
+    price: float = Field(..., ge=0)
+    description: str = Field(default="")
+    quantity: int = Field(..., ge=1)
+
 
 class Stores(BaseModel):
-    name: str
-    items: list[Item]
+    name: str = Field(..., min_length=1)
+    items: list[Item] = Field(..., min_length=1)
+
 
 class ShoppingList(BaseModel):
-    project_name: str = Field()
+    project_name: str = Field(..., min_length=1)
     message: str = Field(..., min_length=1, max_length=4096)
-    total_estimate: float
-    savings: float
-    stores: list[Stores]
-
-class SmartListResponse(BaseModel):
-    """Response returned by the agent for SmartList, combining chat info and the shopping list."""
-    response: str
-    session_id: str
-    user_id: str
-    shopping_list: ShoppingList
+    total_estimate: float = Field(..., ge=0)
+    savings: float = Field(default=0, ge=0)
+    stores: list[Stores] = Field(..., min_length=1)

--- a/agent/sepa_agent.py
+++ b/agent/sepa_agent.py
@@ -18,16 +18,18 @@ ADK web UI / adk run::
 
 """
 
+import json
 import os
+import re
 import socket
 import sys
 from collections.abc import AsyncGenerator
 from pathlib import Path
 from typing import Any
 
-
 from dotenv import load_dotenv
-from google.adk.agents import Agent
+from google.adk.agents import Agent, SequentialAgent
+from google.adk.agents.base_agent import BaseAgent
 from google.adk.models import LiteLlm
 from google.adk.runners import Runner
 from google.adk.sessions import InMemorySessionService
@@ -37,18 +39,23 @@ from google.adk.tools.mcp_tool import (
     StreamableHTTPConnectionParams,
 )
 from google.genai import types
+from pydantic import ValidationError
 
+from agent.api.schemas import ShoppingList
 from agent.observability import configure_langfuse_tracing
-from agent.prompt import SYSTEM_PROMPT
+from agent.shopping_prompts import SHOPPING_FORMATTER_PROMPT, SHOPPING_RESEARCH_PROMPT
 
 # ---------------------------------------------------------------------------
 # Constants — safe at module level (no I/O)
 # ---------------------------------------------------------------------------
 
+
 APP_NAME = "sepa-agent"
 DEFAULT_USER_ID = "local-user"
 DEFAULT_SESSION_ID = "local-session-01"
 _HTTP_PORT = 19121
+RESEARCH_AGENT_NAME = "sepa_shopping_researcher"
+FORMATTER_AGENT_NAME = "sepa_shopping_formatter"
 
 # Toggle via SEPA_AGENT_LOCAL_MODEL=false to force the cloud model.
 LOCAL_ENABLED: bool = os.getenv("SEPA_AGENT_LOCAL_MODEL", "true").lower() not in {
@@ -57,7 +64,7 @@ LOCAL_ENABLED: bool = os.getenv("SEPA_AGENT_LOCAL_MODEL", "true").lower() not in
     "no",
 }
 
-SYSTEM_INSTRUCTIONS: str = SYSTEM_PROMPT
+SYSTEM_INSTRUCTIONS: str = SHOPPING_RESEARCH_PROMPT
 
 # ---------------------------------------------------------------------------
 # Lazily-initialized runtime state
@@ -66,7 +73,7 @@ SYSTEM_INSTRUCTIONS: str = SYSTEM_PROMPT
 # and readers should treat them as Optional; call build_runtime() (or
 # run_prompt, which calls it internally) before accessing them.
 
-root_agent: Agent | None = None
+root_agent: BaseAgent | None = None
 _session_service: InMemorySessionService | None = None
 _runner: Runner | None = None
 
@@ -165,11 +172,25 @@ def build_runtime(*, local: bool | None = None) -> Runner:
         else "gemini-2.5-flash"
     )
 
-    root_agent = Agent(
-        name="sepa_ops_assistant",
+    research_agent = Agent(
+        name=RESEARCH_AGENT_NAME,
         model=model,
-        instruction=SYSTEM_INSTRUCTIONS,
+        instruction=SHOPPING_RESEARCH_PROMPT,
         tools=[audit_tools],
+        output_key="shopping_research",
+    )
+    formatter_agent = Agent(
+        name=FORMATTER_AGENT_NAME,
+        model="gemini-2.5-flash",
+        # model=model,
+        instruction=SHOPPING_FORMATTER_PROMPT,
+        output_schema=ShoppingList,
+        output_key="shopping_list",
+    )
+
+    root_agent = SequentialAgent(
+        name="sepa_shopping_assistant",
+        sub_agents=[research_agent, formatter_agent],
     )
 
     _session_service = InMemorySessionService()
@@ -251,9 +272,7 @@ def run_prompt(
     return final_text
 
 
-async def _ensure_session(
-    user_id: str, session_id: str
-) -> None:
+async def _ensure_session(user_id: str, session_id: str) -> None:
     """Create the session if it does not already exist (async)."""
     svc = _session_service
     if svc is None:
@@ -265,6 +284,42 @@ async def _ensure_session(
         await svc.create_session(
             app_name=APP_NAME, user_id=user_id, session_id=session_id
         )
+
+
+_JSON_BLOCK_RE = re.compile(r"```(?:json)?\s*(.*?)```", re.IGNORECASE | re.DOTALL)
+
+
+def _extract_json_payload(text: str) -> str:
+    """Extract a JSON object from a raw LLM response."""
+    block_match = _JSON_BLOCK_RE.search(text)
+    if block_match:
+        return block_match.group(1).strip()
+
+    start = text.find("{")
+    end = text.rfind("}")
+    if start != -1 and end != -1 and end > start:
+        return text[start : end + 1]
+
+    return text.strip()
+
+
+def _validated_final_event(text: str) -> dict[str, Any]:
+    """Validate and normalize the final shopping-list response."""
+    try:
+        payload = _extract_json_payload(text)
+        shopping_list = ShoppingList.model_validate_json(payload)
+    except (json.JSONDecodeError, ValidationError, ValueError) as exc:
+        return {
+            "type": "error",
+            "content": f"Agent returned invalid ShoppingList JSON: {exc}",
+        }
+
+    data = shopping_list.model_dump(mode="json")
+    return {
+        "type": "final",
+        "content": shopping_list.model_dump_json(),
+        "data": data,
+    }
 
 
 def _event_to_dict(event: Any) -> dict[str, Any]:
@@ -303,7 +358,12 @@ def _event_to_dict(event: Any) -> dict[str, Any]:
         text = ""
         if event.content and event.content.parts:
             text = event.content.parts[0].text or ""
-        return {"type": "final", "content": text}
+        if event.author != FORMATTER_AGENT_NAME:
+            return {
+                "type": "progress",
+                "content": "Research complete. Structuring response...",
+            }
+        return _validated_final_event(text)
 
     # Intermediate / progress
     text = ""
@@ -333,7 +393,7 @@ async def arun_prompt_stream(
 
     Yields:
         Dicts representing agent events (progress, tool_call, tool_result,
-        final, or error).
+        final, or error)
     """
     runner = build_runtime()
     await _ensure_session(user_id, session_id)
@@ -345,7 +405,10 @@ async def arun_prompt_stream(
         session_id=session_id,
         new_message=user_msg,
     ):
-        yield _event_to_dict(event)
+        event_dict = _event_to_dict(event)
+        if event_dict["type"] == "final":
+            yield {"type": "progress", "content": "Structuring response..."}
+        yield event_dict
 
 
 if __name__ == "__main__":

--- a/agent/sepa_agent.py
+++ b/agent/sepa_agent.py
@@ -21,7 +21,10 @@ ADK web UI / adk run::
 import os
 import socket
 import sys
+from collections.abc import AsyncGenerator
 from pathlib import Path
+from typing import Any
+
 
 from dotenv import load_dotenv
 from google.adk.agents import Agent
@@ -181,7 +184,7 @@ def build_runtime(*, local: bool | None = None) -> Runner:
 # ---------------------------------------------------------------------------
 
 
-def _run_sync(coro):
+def _run_sync(coro: Any) -> Any:
     import asyncio
     import concurrent.futures
 
@@ -246,6 +249,103 @@ def run_prompt(
         if event.is_final_response() and event.content and event.content.parts:
             final_text = event.content.parts[0].text or ""
     return final_text
+
+
+async def _ensure_session(
+    user_id: str, session_id: str
+) -> None:
+    """Create the session if it does not already exist (async)."""
+    svc = _session_service
+    if svc is None:
+        raise RuntimeError("Internal error: session service was not initialized.")
+    existing = await svc.get_session(
+        app_name=APP_NAME, user_id=user_id, session_id=session_id
+    )
+    if existing is None:
+        await svc.create_session(
+            app_name=APP_NAME, user_id=user_id, session_id=session_id
+        )
+
+
+def _event_to_dict(event: Any) -> dict[str, Any]:
+    """Convert an ADK Event into a plain dict suitable for SSE serialization."""
+    from google.adk.events.event import Event as _Event
+
+    assert isinstance(event, _Event)
+
+    # Tool calls (function_call parts)
+    func_calls = event.get_function_calls()
+    if func_calls:
+        fc = func_calls[0]
+        return {
+            "type": "tool_call",
+            "content": f"Calling tool: {fc.name}",
+            "tool": fc.name,
+            "args": dict(fc.args) if fc.args else {},
+        }
+
+    # Tool results (function_response parts)
+    func_responses = event.get_function_responses()
+    if func_responses:
+        fr = func_responses[0]
+        # Truncate large tool results to keep SSE payloads manageable.
+        response_str = str(fr.response) if fr.response else ""
+        if len(response_str) > 2000:
+            response_str = response_str[:2000] + "... (truncated)"
+        return {
+            "type": "tool_result",
+            "content": response_str,
+            "tool": fr.name,
+        }
+
+    # Final response
+    if event.is_final_response():
+        text = ""
+        if event.content and event.content.parts:
+            text = event.content.parts[0].text or ""
+        return {"type": "final", "content": text}
+
+    # Intermediate / progress
+    text = ""
+    if event.content and event.content.parts:
+        text = event.content.parts[0].text or ""
+    return {"type": "progress", "content": text or "Agent is thinking..."}
+
+
+async def arun_prompt_stream(
+    prompt: str,
+    *,
+    user_id: str = DEFAULT_USER_ID,
+    session_id: str = DEFAULT_SESSION_ID,
+) -> AsyncGenerator[dict[str, Any], None]:
+    """Async generator that yields structured event dicts from the ADK runner.
+
+    Each yielded dict has at minimum ``{"type": ..., "content": ...}`` and
+    matches the ``SSEEvent`` schema defined in ``agent.api.schemas``.
+
+    This is the primary interface used by the FastAPI streaming endpoint.
+    The existing sync ``run_prompt()`` remains available for CLI / testing.
+
+    Args:
+        prompt: The user's natural-language query.
+        user_id: Identifies the caller; used to scope session state.
+        session_id: Identifies the conversation thread within user_id.
+
+    Yields:
+        Dicts representing agent events (progress, tool_call, tool_result,
+        final, or error).
+    """
+    runner = build_runtime()
+    await _ensure_session(user_id, session_id)
+
+    user_msg = types.Content(role="user", parts=[types.Part(text=prompt)])
+
+    async for event in runner.run_async(
+        user_id=user_id,
+        session_id=session_id,
+        new_message=user_msg,
+    ):
+        yield _event_to_dict(event)
 
 
 if __name__ == "__main__":

--- a/agent/shopping_prompts.py
+++ b/agent/shopping_prompts.py
@@ -1,0 +1,47 @@
+# Prompts for SEPA shopping agents.
+
+SHOPPING_RESEARCH_PROMPT = """
+You are the SEPA shopping research agent.
+
+Your job is to transform the user's food or shopping request into a practical
+shopping plan grounded in SEPA price/store data whenever tools are available.
+
+Use MCP tools when they can answer a question about available tables, products,
+stores, prices, or data freshness. If the current MCP toolset does not yet
+contain price-search tools, continue with a recipe-quantity fallback instead of
+refusing the task.
+
+Research output requirements:
+- Write a compact research brief for the formatter agent, not for the end user.
+- Include the user's goal, servings/person count, inferred ingredients, units or
+  quantities, and any store/price evidence found through tools.
+- Avoid running long queries on historical data, focus on the 'latest' date
+  no multi date queries, the 'latest' date might not be the current date and
+  might not even be the same month.
+- If no live SEPA price evidence is available, say that clearly and mark item
+  prices as pending or 0.0. Do not invent SEPA-backed prices.
+- The final answer from this agent does not need to match the UI schema.
+"""
+
+
+SHOPPING_FORMATTER_PROMPT = """
+You are the SEPA shopping response formatter.
+
+Convert the research brief below into the exact ShoppingList JSON expected by
+the frontend.
+
+Research brief:
+{shopping_research}
+
+Rules:
+- Output only one JSON object. Do not wrap it in markdown.
+- Preserve Spanish if the user wrote in Spanish.
+- Always include at least one store object.
+- If the research brief has no live SEPA prices, use store name
+  "Estimación sin precios SEPA" and price 0.0 for each item.
+- Keep item quantities as positive integers. Put package/unit details in each
+  item description when needed.
+- total_estimate must equal the sum of item price * quantity when prices are
+  known. Use 0.0 when all prices are pending.
+- savings must be 0.0 unless the research brief contains a real comparison.
+"""

--- a/agent/tests/test_api.py
+++ b/agent/tests/test_api.py
@@ -1,0 +1,304 @@
+"""Tests for the Agent HTTP API (FastAPI).
+
+These tests mock the ADK runner so they can run without MCP, MinIO, or
+a running LLM server.  They verify request/response contracts, SSE
+streaming format, session management, and error handling.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncGenerator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agent.api.schemas import ChatRequest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def _mock_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch build_runtime so the app starts without real MCP/LLM."""
+    from agent import sepa_agent
+
+    mock_agent = MagicMock()
+    mock_agent.name = "test_agent"
+
+    mock_session_svc = MagicMock()
+    # Make get_session and create_session proper async mocks
+    mock_session_svc.get_session = AsyncMock(return_value=None)
+    mock_session_svc.create_session = AsyncMock(return_value=MagicMock())
+
+    mock_runner = MagicMock()
+
+    monkeypatch.setattr(sepa_agent, "root_agent", mock_agent)
+    monkeypatch.setattr(sepa_agent, "_session_service", mock_session_svc)
+    monkeypatch.setattr(sepa_agent, "_runner", mock_runner)
+    monkeypatch.setattr(
+        sepa_agent,
+        "build_runtime",
+        lambda **kwargs: mock_runner,
+    )
+    monkeypatch.setattr(sepa_agent, "_load_agent_env", lambda: None)
+
+
+@pytest.fixture()
+def client(_mock_runtime: None) -> TestClient:
+    """TestClient with mocked runtime — no real agent needed."""
+    from agent.api.app import app
+
+    return TestClient(app)
+
+
+def _make_fake_events() -> list[dict[str, Any]]:
+    """Return a list of event dicts simulating a typical agent interaction."""
+    return [
+        {"type": "progress", "content": "Agent is thinking..."},
+        {
+            "type": "tool_call",
+            "content": "Calling tool: list_tables",
+            "tool": "list_tables",
+            "args": {"namespace": "sepa"},
+        },
+        {
+            "type": "tool_result",
+            "content": "['dim_productos', 'dim_sucursales']",
+            "tool": "list_tables",
+        },
+        {"type": "final", "content": "There are 2 tables in the sepa namespace."},
+    ]
+
+
+async def _fake_arun_prompt_stream(
+    prompt: str,
+    *,
+    user_id: str = "web-user",
+    session_id: str = "test-session",
+) -> AsyncGenerator[dict[str, Any], None]:
+    """Async generator yielding fake events."""
+    for event in _make_fake_events():
+        yield event
+
+
+# ---------------------------------------------------------------------------
+# Health endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestHealth:
+    def test_health_returns_ok(self, client: TestClient) -> None:
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+        assert data["agent_name"] == "test_agent"
+        assert "uptime_seconds" in data
+
+    def test_health_has_model_field(self, client: TestClient) -> None:
+        resp = client.get("/health")
+        data = resp.json()
+        assert "model" in data
+
+
+# ---------------------------------------------------------------------------
+# Non-streaming chat
+# ---------------------------------------------------------------------------
+
+
+class TestChat:
+    @patch(
+        "agent.api.routes.arun_prompt_stream",
+        side_effect=_fake_arun_prompt_stream,
+        create=True,
+    )
+    def test_chat_returns_final_response(
+        self, mock_stream: MagicMock, client: TestClient
+    ) -> None:
+        # We need to patch the import inside routes.py
+        with patch(
+            "agent.sepa_agent.arun_prompt_stream",
+            side_effect=_fake_arun_prompt_stream,
+        ):
+            resp = client.post(
+                "/api/agent/chat",
+                json={"prompt": "How many tables are there?"},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["response"] == "There are 2 tables in the sepa namespace."
+        assert "session_id" in data
+        assert data["user_id"] == "web-user"
+
+    def test_chat_rejects_empty_prompt(self, client: TestClient) -> None:
+        resp = client.post(
+            "/api/agent/chat",
+            json={"prompt": ""},
+        )
+        assert resp.status_code == 422  # Pydantic validation
+
+    def test_chat_uses_custom_user_id(self, client: TestClient) -> None:
+        with patch(
+            "agent.sepa_agent.arun_prompt_stream",
+            side_effect=_fake_arun_prompt_stream,
+        ):
+            resp = client.post(
+                "/api/agent/chat",
+                json={
+                    "prompt": "hello",
+                    "user_id": "custom-user",
+                    "session_id": "custom-session",
+                },
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["user_id"] == "custom-user"
+        assert data["session_id"] == "custom-session"
+
+
+# ---------------------------------------------------------------------------
+# SSE streaming
+# ---------------------------------------------------------------------------
+
+
+class TestStreaming:
+    def test_stream_returns_sse_content_type(self, client: TestClient) -> None:
+        with patch(
+            "agent.sepa_agent.arun_prompt_stream",
+            side_effect=_fake_arun_prompt_stream,
+        ):
+            resp = client.post(
+                "/api/agent/stream",
+                json={"prompt": "list tables"},
+            )
+        assert resp.status_code == 200
+        assert "text/event-stream" in resp.headers["content-type"]
+
+    def test_stream_yields_valid_sse_events(self, client: TestClient) -> None:
+        with patch(
+            "agent.sepa_agent.arun_prompt_stream",
+            side_effect=_fake_arun_prompt_stream,
+        ):
+            resp = client.post(
+                "/api/agent/stream",
+                json={"prompt": "list tables"},
+            )
+        lines = resp.text.strip().split("\n")
+        data_lines = [
+            line for line in lines if line.startswith("data: ")
+        ]
+
+        # Last data line should be [DONE]
+        assert data_lines[-1] == "data: [DONE]"
+
+        # All other data lines should be valid JSON
+        event_lines = data_lines[:-1]
+        assert len(event_lines) >= 1
+
+        for line in event_lines:
+            payload = line.removeprefix("data: ")
+            parsed = json.loads(payload)
+            assert "type" in parsed
+            assert "session_id" in parsed
+
+    def test_stream_includes_final_event(self, client: TestClient) -> None:
+        with patch(
+            "agent.sepa_agent.arun_prompt_stream",
+            side_effect=_fake_arun_prompt_stream,
+        ):
+            resp = client.post(
+                "/api/agent/stream",
+                json={"prompt": "list tables"},
+            )
+        lines = resp.text.strip().split("\n")
+        data_lines = [
+            line for line in lines
+            if line.startswith("data: ") and line != "data: [DONE]"
+        ]
+
+        events = [
+            json.loads(line.removeprefix("data: "))
+            for line in data_lines
+        ]
+        types = [e["type"] for e in events]
+        assert "final" in types
+
+    def test_stream_handles_errors_gracefully(self, client: TestClient) -> None:
+        async def _exploding_stream(
+            prompt: str, **kwargs: Any
+        ) -> AsyncGenerator[dict[str, Any], None]:
+            yield {"type": "progress", "content": "starting"}
+            raise RuntimeError("LLM connection failed")
+
+        with patch(
+            "agent.sepa_agent.arun_prompt_stream",
+            side_effect=_exploding_stream,
+        ):
+            resp = client.post(
+                "/api/agent/stream",
+                json={"prompt": "will fail"},
+            )
+        assert resp.status_code == 200  # SSE always returns 200
+
+        lines = resp.text.strip().split("\n")
+        data_lines = [
+            line for line in lines
+            if line.startswith("data: ") and line != "data: [DONE]"
+        ]
+
+        events = [
+            json.loads(line.removeprefix("data: "))
+            for line in data_lines
+        ]
+        error_events = [e for e in events if e["type"] == "error"]
+        assert len(error_events) == 1
+        assert "LLM connection failed" in error_events[0]["content"]
+
+
+# ---------------------------------------------------------------------------
+# Session management
+# ---------------------------------------------------------------------------
+
+
+class TestSessions:
+    def test_list_sessions_empty(self, client: TestClient) -> None:
+        resp = client.get("/api/agent/sessions/some-user")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["user_id"] == "some-user"
+        assert data["sessions"] == []
+
+    def test_delete_session_not_found(self, client: TestClient) -> None:
+        resp = client.delete("/api/agent/sessions/user1/nonexistent")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Schema validation
+# ---------------------------------------------------------------------------
+
+
+class TestSchemas:
+    def test_chat_request_defaults(self) -> None:
+        req = ChatRequest(prompt="hello")
+        assert req.user_id == "web-user"
+        assert req.session_id is None
+
+    def test_chat_request_max_length(self) -> None:
+        with pytest.raises(Exception):
+            ChatRequest(prompt="x" * 4001)
+
+    def test_chat_request_custom_fields(self) -> None:
+        req = ChatRequest(
+            prompt="query",
+            user_id="u1",
+            session_id="s1",
+        )
+        assert req.user_id == "u1"
+        assert req.session_id == "s1"

--- a/agent/tests/test_sepa_agent_events.py
+++ b/agent/tests/test_sepa_agent_events.py
@@ -1,0 +1,77 @@
+from google.adk.events.event import Event
+from google.genai import types
+
+from agent.sepa_agent import FORMATTER_AGENT_NAME, RESEARCH_AGENT_NAME, _event_to_dict
+
+
+def _text_event(author: str, text: str) -> Event:
+    return Event(
+        author=author,
+        content=types.Content(role="model", parts=[types.Part(text=text)]),
+    )
+
+
+def test_research_final_event_becomes_progress() -> None:
+    event = _text_event(RESEARCH_AGENT_NAME, "Found recipe ingredients.")
+
+    payload = _event_to_dict(event)
+
+    assert payload == {
+        "type": "progress",
+        "content": "Research complete. Structuring response...",
+    }
+
+
+def test_formatter_final_event_is_validated_shopping_list() -> None:
+    event = _text_event(
+        FORMATTER_AGENT_NAME,
+        """
+        ```json
+        {
+          "project_name": "Tiramisu para 5 personas",
+          "message": "Precios pendientes de MCP.",
+          "total_estimate": 0.0,
+          "savings": 0.0,
+          "stores": [
+            {
+              "name": "Estimación sin precios SEPA",
+              "items": [
+                {
+                  "name": "Mascarpone",
+                  "price": 0.0,
+                  "description": "500 g",
+                  "quantity": 1
+                }
+              ]
+            }
+          ]
+        }
+        ```
+        """,
+    )
+
+    payload = _event_to_dict(event)
+
+    assert payload["type"] == "final"
+    assert payload["data"]["project_name"] == "Tiramisu para 5 personas"
+    assert payload["data"]["stores"][0]["items"][0]["quantity"] == 1
+
+
+def test_formatter_invalid_shopping_list_becomes_error() -> None:
+    event = _text_event(
+        FORMATTER_AGENT_NAME,
+        """
+        {
+          "project_name": "Tiramisu",
+          "message": "No data.",
+          "total_estimate": 0.0,
+          "savings": 0.0,
+          "stores": []
+        }
+        """,
+    )
+
+    payload = _event_to_dict(event)
+
+    assert payload["type"] == "error"
+    assert "invalid ShoppingList JSON" in payload["content"]

--- a/mcp/lakehouse_mcp/tools/query.py
+++ b/mcp/lakehouse_mcp/tools/query.py
@@ -25,6 +25,23 @@ def _assert_read_only(sql: str) -> None:
         )
 
 
+def _normalize_registered_table_names(sql: str) -> str:
+    """Map Iceberg-style table names to DuckDB's registered in-memory views."""
+    registered = get_registered_views()
+    if not registered:
+        return sql
+
+    normalized = sql
+    for table_name in sorted(registered, key=len, reverse=True):
+        normalized = re.sub(
+            rf"\bsepa\.{re.escape(table_name)}\b",
+            table_name,
+            normalized,
+            flags=re.IGNORECASE,
+        )
+    return normalized
+
+
 def run_query(sql: str, limit: int = 1000) -> List[Dict[str, Any]]:
     """
     Run a read-only SQL SELECT query over the Iceberg tables using DuckDB.
@@ -34,6 +51,7 @@ def run_query(sql: str, limit: int = 1000) -> List[Dict[str, Any]]:
     """
     try:
         _assert_read_only(sql)
+        sql = _normalize_registered_table_names(sql)
 
         conn = get_connection()
         if conn is None:

--- a/mcp/tests/test_query_tools.py
+++ b/mcp/tests/test_query_tools.py
@@ -1,0 +1,46 @@
+from typing import Any
+
+import polars as pl
+
+from lakehouse_mcp.tools import query
+
+
+class _FakeResult:
+    def pl(self) -> pl.DataFrame:
+        return pl.DataFrame({"ok": [True]})
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.executed_sql = ""
+
+    def execute(self, sql: str) -> _FakeResult:
+        self.executed_sql = sql
+        return _FakeResult()
+
+
+def test_run_query_normalizes_sepa_prefix_for_registered_views(
+    monkeypatch: Any,
+) -> None:
+    conn = _FakeConnection()
+    monkeypatch.setattr(query, "get_connection", lambda: conn)
+    monkeypatch.setattr(
+        query,
+        "get_registered_views",
+        lambda: frozenset({"precios", "dim_comercios"}),
+    )
+
+    result = query.run_query(
+        """
+        SELECT p.descripcion, c.nombre
+        FROM sepa.precios p
+        JOIN sepa.dim_comercios c ON p.id_comercio = c.id_comercio
+        """,
+    )
+
+    assert result == [{"ok": True}]
+    assert "sepa.precios" not in conn.executed_sql
+    assert "sepa.dim_comercios" not in conn.executed_sql
+    assert "FROM precios p" in conn.executed_sql
+    assert "JOIN dim_comercios c" in conn.executed_sql
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,14 @@ dependencies = [
     "fastmcp>=3.3.1",
     "langfuse>=4.7.0",
     "openinference-instrumentation-google-adk>=0.1.15",
+    "fastapi>=0.115.0",
+    "uvicorn[standard]>=0.30.0",
 ]
 
 requires-python = ">=3.12,<3.14"
+
+[project.scripts]
+sepa-api = "agent.api.cli:main"
 
 [dependency-groups]
 dev = [

--- a/src/sepa_pipeline/config.py
+++ b/src/sepa_pipeline/config.py
@@ -7,7 +7,7 @@ environment variables. Data model definitions live in schema.py.
 
 import os
 from pathlib import Path
-from typing import Dict
+from typing import Any, Dict
 
 import polars as pl
 from dotenv import load_dotenv
@@ -55,18 +55,17 @@ class SEPAConfig:
         self.gcp_location: str | None = os.getenv("GCP_LOCATION", "US")
 
         required = {
-            "MINIO_ENDPOINT":    self.minio_endpoint,
-            "MINIO_BUCKET":      self.minio_bucket,
+            "MINIO_ENDPOINT": self.minio_endpoint,
+            "MINIO_BUCKET": self.minio_bucket,
         }
         missing = [k for k, v in required.items() if not v]
         if missing:
             raise ValueError(
-                "Missing required environment variables: "
-                f"{', '.join(missing)}"
+                f"Missing required environment variables: {', '.join(missing)}"
             )
 
     @property
-    def iceberg_catalog_config(self) -> dict:
+    def iceberg_catalog_config(self) -> dict[str, Any]:
         """PyIceberg REST Catalog config for Nessie (local MinIO)."""
         endpoint = self.minio_endpoint
         assert endpoint is not None

--- a/uv.lock
+++ b/uv.lock
@@ -1830,6 +1830,28 @@ wheels = [
 ]
 
 [[package]]
+name = "httptools"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/e5/d471fcb0e14523fe1c3f4ba58ca52480e7bd70ad7109a3846bc75892f7fb/httptools-0.8.0.tar.gz", hash = "sha256:6b2a32f18d97e16e90827d7a819ffa8dbd8cc245fc4e1fa9d1095b54ef4bd999", size = 271342, upload-time = "2026-05-25T22:17:48.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/88/1d21a36da8f5cb0fa49eafd4b169eba5608d57e75bbcf61845cbc6243216/httptools-0.8.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:880490234c10f70a9830743097e8958d6e4b9f5a0ffc24515023afeef984054d", size = 208247, upload-time = "2026-05-25T22:17:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/42/cc4feea2945cb3051038f090c9b36bd5b8a9d7f5a894a506a8983e33fd1c/httptools-0.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5931891fb7b441b8a3853cf1b85c82c903defce084dd5f6771ca46e31bf862c5", size = 113064, upload-time = "2026-05-25T22:17:09.136Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/a6/febbb8b8db0f58b38e44ad6cb946e6a255ae49b55f2e8543408fb7501ccd/httptools-0.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b15fc622b0f869d19207c4089a501d9bcc63ca5e071ffdd2f03f922df882dcb2", size = 523851, upload-time = "2026-05-25T22:17:10.106Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e4/f90a0df0b83beff265b7e3b65f2a4cefd95792d4be0ac3e16049f2acd3c2/httptools-0.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:425f83884fd6343828d8c565f046cb72b6d19063f6924093e11bcd8e1548cd09", size = 518842, upload-time = "2026-05-25T22:17:11.218Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/2d/0c9ac76dd2c893841fbf6498d6acec4f2442e1b7067f6e3e316a80e494e8/httptools-0.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ef7c3c97f4311c7be57e2986629df89d49cb434dbff78eafcd48c2bff986b15a", size = 501238, upload-time = "2026-05-25T22:17:12.728Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/42/906adc91ae3a5fa9c59c0a2f21c139725bd7e5b41ae6acd485cd14123ebf/httptools-0.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a1afd7c9fbff0d9f5d489c4ce2768bd09c84a46ddefc7161e6aa82ae35c85745", size = 509567, upload-time = "2026-05-25T22:17:13.842Z" },
+    { url = "https://files.pythonhosted.org/packages/05/0b/4240efeb672751ee5b9b380cb0e3fdc050bc05f68adc7a8aefc4fcd9a69a/httptools-0.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:cd96f29b4bab1d42fa6e3d008711c75e0f79e94e06827330160e3a304227f150", size = 90918, upload-time = "2026-05-25T22:17:15.155Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e5/8cfcabc5546e8022f168be28bcdaa128a240a0befdd03b59d558b4f18bd6/httptools-0.8.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:614ceea8ea606848bece2338ac03b3ce5324bcb4be8dc7d377ed708012fa4db8", size = 205148, upload-time = "2026-05-25T22:17:16.333Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/0e/0fb14848c19a686c8062ff9067c1a48793e3224b47bc5b201535b6036fce/httptools-0.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2d689918c15a013c65ef52d9fd495d766893ab831a2c8d89f2ac5940a5df847c", size = 111368, upload-time = "2026-05-25T22:17:17.586Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1b/46f1cecf06b9bbde8e4b8c88034ac7908989e5ff7a3a388ef38392949c1f/httptools-0.8.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:eb3028cca2fc0a6d720e52ef61d8ebb62fcbfeb1de56874546d858d3f25a26b7", size = 486447, upload-time = "2026-05-25T22:17:18.564Z" },
+    { url = "https://files.pythonhosted.org/packages/77/00/258bfc0837221f81d9725c45f9b948a6a6b2994a147a4fb66e85100c668f/httptools-0.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:88bdd940f2b5d487b4d032c6afa5489a7dc4694410d43de3c38c4fb3af0dc45d", size = 482448, upload-time = "2026-05-25T22:17:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/04/ab/d1cef3b5523f4d272a70f42a776c3169a2dddfe3a54de4b2ce4a36341528/httptools-0.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6a43c9dd399758ccc0531acb0a3c4a6c299ee893ee9400e9c893b7bdcfae0681", size = 464460, upload-time = "2026-05-25T22:17:20.882Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/5d1d072442277bb2b3434e0e60690b8e8c23840ef7de8b6ea54040a536d3/httptools-0.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0770728beb05094c809b98e814edff5fef69d26ad7d21185f2f6d5884a0ba683", size = 471312, upload-time = "2026-05-25T22:17:22.085Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/66/b96623b27e51a68199ef4efdda0613cced9233fe3062ac74e50749c5ad37/httptools-0.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:7685df791fad561384bfb139e77fde27a1ffd93134e016f95a0db424ffbf77b1", size = 90117, upload-time = "2026-05-25T22:17:23.074Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4959,6 +4981,7 @@ dependencies = [
     { name = "dbt-bigquery" },
     { name = "dbt-core" },
     { name = "dbt-duckdb" },
+    { name = "fastapi" },
     { name = "fastmcp" },
     { name = "google-adk", extra = ["extensions"] },
     { name = "google-cloud-bigquery" },
@@ -4972,6 +4995,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "tenacity" },
     { name = "tqdm" },
+    { name = "uvicorn", extra = ["standard"] },
 ]
 
 [package.dev-dependencies]
@@ -5004,6 +5028,7 @@ requires-dist = [
     { name = "dbt-bigquery", specifier = ">=1.9.0" },
     { name = "dbt-core", specifier = ">=1.9.0" },
     { name = "dbt-duckdb", specifier = ">=1.9.0" },
+    { name = "fastapi", specifier = ">=0.115.0" },
     { name = "fastmcp", specifier = ">=3.3.1" },
     { name = "google-adk", extras = ["extensions"], specifier = ">=2.1.0" },
     { name = "google-cloud-bigquery", specifier = ">=3.13.0" },
@@ -5017,6 +5042,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "tenacity", specifier = ">=9.1.2,<10.0.0" },
     { name = "tqdm", specifier = ">=4.67.1,<5.0.0" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -5542,6 +5568,37 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f6/b1/8e7077a8641086aea449e1b5752a570f1b5906c64e0a33cd6d93b63a066b/uvicorn-0.47.0.tar.gz", hash = "sha256:7c9a0ea1a9414106bbab7324609c162d8fa0cdcdcb703060987269d77c7bb533", size = 90582, upload-time = "2026-05-14T18:16:54.455Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/15/41/ac2dfdbc1f60c7af4f994c7a335cfa7040c01642b605d65f611cecc2a1e4/uvicorn-0.47.0-py3-none-any.whl", hash = "sha256:2c5715bc12d1892d84752049f400cd1c3cb018514967fdfeb97640443a6a9432", size = 71301, upload-time = "2026-05-14T18:16:51.762Z" },
+]
+
+[package.optional-dependencies]
+standard = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "httptools" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/ff/7f72e8170be527b4977b033239a83a68d5c881cc4775fca255c677f7ac5d/uvloop-0.22.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fe94b4564e865d968414598eea1a6de60adba0c040ba4ed05ac1300de402cd42", size = 1359936, upload-time = "2025-10-16T22:16:29.436Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c6/e5d433f88fd54d81ef4be58b2b7b0cea13c442454a1db703a1eea0db1a59/uvloop-0.22.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:51eb9bd88391483410daad430813d982010f9c9c89512321f5b60e2cddbdddd6", size = 752769, upload-time = "2025-10-16T22:16:30.493Z" },
+    { url = "https://files.pythonhosted.org/packages/24/68/a6ac446820273e71aa762fa21cdcc09861edd3536ff47c5cd3b7afb10eeb/uvloop-0.22.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:700e674a166ca5778255e0e1dc4e9d79ab2acc57b9171b79e65feba7184b3370", size = 4317413, upload-time = "2025-10-16T22:16:31.644Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b5b1ac819a3f946d3b2ee07f09149578ae76066d70b44df3fa990add49a82e4", size = 4426307, upload-time = "2025-10-16T22:16:32.917Z" },
+    { url = "https://files.pythonhosted.org/packages/90/60/97362554ac21e20e81bcef1150cb2a7e4ffdaf8ea1e5b2e8bf7a053caa18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e047cc068570bac9866237739607d1313b9253c3051ad84738cbb095be0537b2", size = 4131970, upload-time = "2025-10-16T22:16:34.015Z" },
+    { url = "https://files.pythonhosted.org/packages/99/39/6b3f7d234ba3964c428a6e40006340f53ba37993f46ed6e111c6e9141d18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:512fec6815e2dd45161054592441ef76c830eddaad55c8aa30952e6fe1ed07c0", size = 4296343, upload-time = "2025-10-16T22:16:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/89/8c/182a2a593195bfd39842ea68ebc084e20c850806117213f5a299dfc513d9/uvloop-0.22.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:561577354eb94200d75aca23fbde86ee11be36b00e52a4eaf8f50fb0c86b7705", size = 1358611, upload-time = "2025-10-16T22:16:36.833Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/e301ee96a6dc95224b6f1162cd3312f6d1217be3907b79173b06785f2fe7/uvloop-0.22.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cdf5192ab3e674ca26da2eada35b288d2fa49fdd0f357a19f0e7c4e7d5077c8", size = 751811, upload-time = "2025-10-16T22:16:38.275Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/02/654426ce265ac19e2980bfd9ea6590ca96a56f10c76e63801a2df01c0486/uvloop-0.22.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e2ea3d6190a2968f4a14a23019d3b16870dd2190cd69c8180f7c632d21de68d", size = 4288562, upload-time = "2025-10-16T22:16:39.375Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e", size = 4366890, upload-time = "2025-10-16T22:16:40.547Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/53/8369e5219a5855869bcee5f4d317f6da0e2c669aecf0ef7d371e3d084449/uvloop-0.22.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc5ef13bbc10b5335792360623cc378d52d7e62c2de64660616478c32cd0598e", size = 4119472, upload-time = "2025-10-16T22:16:41.694Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ba/d69adbe699b768f6b29a5eec7b47dd610bd17a69de51b251126a801369ea/uvloop-0.22.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1f38ec5e3f18c8a10ded09742f7fb8de0108796eb673f30ce7762ce1b8550cad", size = 4239051, upload-time = "2025-10-16T22:16:43.224Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes the work tracked in **[SEP-276](https://linear.app/sepa/issue/SEP-276/shopping-agent-workflow-researchformatter-split-sse-api-validation-mcp)** (builds on SEP-273).

This PR delivers the website-facing shopping assistant path end-to-end on the agent side:

1. **FastAPI streaming API** for agent chat (`/api/agent/stream`, `/api/agent/chat`, health, sessions) with `sepa-api` entrypoint.
2. **Two-stage ADK shopping workflow** so MCP tool use and structured frontend JSON are not forced into the same LLM request.
3. **MCP DuckDB SQL fix** so catalog-style `sepa.<table>` names resolve to registered in-memory views.
4. **Tests** for SSE event shaping and SQL prefix rewrite.


## What changed

### Agent workflow
- `SequentialAgent` root: `sepa_shopping_assistant`
  - **Researcher** (`sepa_shopping_researcher`): MCP tools, local/cloud via `SEPA_AGENT_LOCAL_MODEL`, writes `shopping_research`
  - **Formatter** (`sepa_shopping_formatter`): **hardcoded `gemini-2.5-flash`**, no tools, `output_schema=ShoppingList`, writes `shopping_list`
- Tracked prompts in `agent/shopping_prompts.py` (research fallback when price tools are missing; zero-price estimate store when no live SEPA evidence)

### SSE / schema contract
- Research sub-agent finals emit as **progress** (not final)
- Formatter final is **Pydantic-validated**; invalid JSON → **error** event
- `SSEEvent.data` carries the parsed shopping list for the frontend
- Tighter `ShoppingList` constraints (non-empty names, ≥1 store/item, non-negative prices, positive quantities)

### MCP
- `run_query` rewrites only `sepa.<registered_view>` → `<view>` for DuckDB
- Keeps read-only SELECT guard and row cap

### Chore
- Ignore local editor dirs (`.zed/`, etc.); minor `config.py` typing cleanup

## Out of scope
- `manage_iceberg.py` changes (left local for a later PR / SEP-274 area)
- Curated shopping MCP tools (still on roadmap; free-form `run_query` remains for exploration)
- API/MCP auth

## Follow-ups
- Replace ADK `SequentialAgent` with Workflows when ready (deprecation path noted in commit)
- Curated price/search tools instead of open SQL for product use

## Test plan
- [x] `uv run pytest agent/tests/test_api.py agent/tests/test_observability.py agent/tests/test_sepa_agent_events.py mcp/tests/test_query_tools.py -q --no-cov`
- [ ] Manual: `sepa-api` + MCP on `:19121`, stream a shopping prompt, confirm final SSE has validated `data`
- [ ] Confirm researcher can use local model while formatter hits Gemini