### PR TITLE
[SEP-277] Implement atomic day write

### DIFF
--- a/src/sepa_pipeline/loaders/parquet_loader.py
+++ b/src/sepa_pipeline/loaders/parquet_loader.py
@@ -5,13 +5,19 @@ Reads all child ZIP CSVs (comercio, sucursales, productos) extracted from the
 daily master ZIP, concatenates each table type, and writes a single Parquet
 file per table per date to bronze/parquet/.
 
+Writes are staged under ``.staging/`` and committed only when all three tables
+succeed, then a ``_SUCCESS`` marker is written. ``exists()`` requires the
+marker plus all three files so incomplete days are never treated as cache hits.
+
 Also provides read access so the silver pipeline can skip ZIP extraction
 on subsequent runs.
 """
 
+from __future__ import annotations
+
 from datetime import date
 from pathlib import Path
-from typing import Dict, List
+from typing import Any, Dict, List
 
 import polars as pl
 import pyarrow.parquet as pq
@@ -24,6 +30,10 @@ from sepa_pipeline.utils.logger import get_logger
 logger = get_logger(__name__)
 
 TABLE_TYPES = ("comercio", "sucursales", "productos")
+STAGING_DIR = ".staging"
+SUCCESS_MARKER = "_SUCCESS"
+# Chunk size for staging → final stream copy (avoids pyarrow copy_file quirks).
+_COPY_CHUNK_BYTES = 8 * 1024 * 1024
 
 
 class ParquetLoader:
@@ -32,9 +42,14 @@ class ParquetLoader:
     and provides read access for downstream silver processing.
     """
 
-    def __init__(self, config: SEPAConfig):
+    def __init__(
+        self,
+        config: SEPAConfig,
+        filesystem: fs.FileSystem | None = None,
+    ):
         self.config = config
-        self._s3 = fs.S3FileSystem(
+        # Injected filesystem is used in tests (LocalFileSystem / SubTreeFileSystem).
+        self._s3: fs.FileSystem = filesystem or fs.S3FileSystem(
             endpoint_override=config.minio_endpoint,
             access_key=config.minio_access_key,
             secret_key=config.minio_secret_key,
@@ -53,14 +68,93 @@ class ParquetLoader:
     def _parquet_path(self, fecha_vigencia: date, table_type: str) -> str:
         return f"{self._parquet_prefix(fecha_vigencia)}/{table_type}.parquet"
 
-    def exists(self, fecha_vigencia: date) -> bool:
-        """Check if all three bronze parquet files exist for a given date."""
+    def _staging_prefix(self, fecha_vigencia: date) -> str:
+        return f"{self._parquet_prefix(fecha_vigencia)}/{STAGING_DIR}"
+
+    def _staging_path(self, fecha_vigencia: date, table_type: str) -> str:
+        return f"{self._staging_prefix(fecha_vigencia)}/{table_type}.parquet"
+
+    def _success_path(self, fecha_vigencia: date) -> str:
+        return f"{self._parquet_prefix(fecha_vigencia)}/{SUCCESS_MARKER}"
+
+    def _file_exists(self, path: str) -> bool:
+        info = self._s3.get_file_info(path)
+        return bool(info.type != fs.FileType.NotFound)
+
+    def _delete_if_exists(self, path: str) -> None:
+        if self._file_exists(path):
+            self._s3.delete_file(path)
+
+    def _ensure_parent(self, path: str) -> None:
+        """Create parent directories when the backend requires them (local FS)."""
+        parent, sep, _ = path.rpartition("/")
+        if sep and parent:
+            self._s3.create_dir(parent, recursive=True)
+
+    def _open_output(self, path: str) -> Any:
+        """Open an output stream, ensuring parent dirs exist for local FS."""
+        self._ensure_parent(path)
+        return self._s3.open_output_stream(path)
+
+    def _copy_object(self, src: str, dst: str) -> None:
+        """Stream-copy one object (works on S3 and LocalFileSystem)."""
+        with self._s3.open_input_stream(src) as inp:
+            with self._open_output(dst) as out:
+                while True:
+                    chunk = inp.read(_COPY_CHUNK_BYTES)
+                    if not chunk:
+                        break
+                    out.write(chunk)
+
+    def _cleanup_staging(self, fecha_vigencia: date) -> None:
         for table_type in TABLE_TYPES:
-            path = self._parquet_path(fecha_vigencia, table_type)
-            info = self._s3.get_file_info(path)
-            if info.type == fs.FileType.NotFound:
+            self._delete_if_exists(self._staging_path(fecha_vigencia, table_type))
+
+    def exists(self, fecha_vigencia: date) -> bool:
+        """
+        Return True only for a fully committed bronze day.
+
+        Requires ``_SUCCESS`` plus all three parquet files so partial writes
+        and mid-commit rebuilds are never treated as cache hits.
+        """
+        if not self._file_exists(self._success_path(fecha_vigencia)):
+            return False
+        for table_type in TABLE_TYPES:
+            if not self._file_exists(self._parquet_path(fecha_vigencia, table_type)):
                 return False
         return True
+
+    def _commit_day(self, fecha_vigencia: date) -> None:
+        """
+        Promote staged files to final paths and write ``_SUCCESS``.
+
+        ``_SUCCESS`` is removed first so a mid-commit failure cannot leave a
+        cache hit with mixed old/new tables.
+        """
+        for table_type in TABLE_TYPES:
+            staging = self._staging_path(fecha_vigencia, table_type)
+            if not self._file_exists(staging):
+                raise RuntimeError(
+                    f"Cannot commit bronze day {fecha_vigencia}: "
+                    f"missing staged {table_type}.parquet"
+                )
+
+        # Invalidate cache for the duration of the commit.
+        self._delete_if_exists(self._success_path(fecha_vigencia))
+
+        for table_type in TABLE_TYPES:
+            staging = self._staging_path(fecha_vigencia, table_type)
+            final = self._parquet_path(fecha_vigencia, table_type)
+            self._copy_object(staging, final)
+            logger.info(f"[BRONZE] Committed {table_type}.parquet -> s3://{final}")
+
+        with self._open_output(self._success_path(fecha_vigencia)) as out:
+            out.write(b"")
+
+        self._cleanup_staging(fecha_vigencia)
+        logger.info(
+            f"[BRONZE] Day {fecha_vigencia} committed ({SUCCESS_MARKER} written)"
+        )
 
     def build(
         self,
@@ -69,6 +163,10 @@ class ParquetLoader:
     ) -> Dict[str, Dict]:
         """
         Read all extracted CSVs, concatenate by table type, write Parquet to MinIO.
+
+        Files are written under ``.staging/`` first. Only when all three tables
+        stage successfully are they promoted to the day prefix and ``_SUCCESS``
+        written. On partial failure, any prior committed day is left intact.
 
         Returns audit metadata per table type:
             {
@@ -82,75 +180,98 @@ class ParquetLoader:
             f"from {len(all_csv_paths)} child ZIPs"
         )
 
+        # Drop leftovers from a previous failed attempt before staging again.
+        self._cleanup_staging(fecha_vigencia)
+
         audit: Dict[str, Dict] = {}
+        staged: list[str] = []
 
-        for table_type in TABLE_TYPES:
-            schema = get_schema_dict(table_type)
+        try:
+            for table_type in TABLE_TYPES:
+                schema = get_schema_dict(table_type)
 
-            frames: list[pl.DataFrame] = []
-            total_csv_rows = 0
-            csv_cols = 0
+                frames: list[pl.DataFrame] = []
+                total_csv_rows = 0
+                csv_cols = 0
 
-            for csv_paths in all_csv_paths:
-                if table_type not in csv_paths:
-                    continue
-                try:
-                    df = pl.read_csv(
-                        csv_paths[table_type],
-                        separator="|",
-                        encoding="utf8-lossy",
-                        has_header=True,
-                        null_values=["", "NULL", "null"],
-                        schema_overrides=schema,
-                        truncate_ragged_lines=True,
-                        ignore_errors=True,
-                        quote_char=None,
-                    )
-                    df = df.rename(
-                        {col: col.lstrip("\ufeff").strip() for col in df.columns}
-                    )
-                    total_csv_rows += df.height
-                    csv_cols = len(df.columns)
-                    frames.append(df)
-                except Exception as e:
+                for csv_paths in all_csv_paths:
+                    if table_type not in csv_paths:
+                        continue
+                    try:
+                        df = pl.read_csv(
+                            csv_paths[table_type],
+                            separator="|",
+                            encoding="utf8-lossy",
+                            has_header=True,
+                            null_values=["", "NULL", "null"],
+                            schema_overrides=schema,
+                            truncate_ragged_lines=True,
+                            ignore_errors=True,
+                            quote_char=None,
+                        )
+                        df = df.rename(
+                            {col: col.lstrip("\ufeff").strip() for col in df.columns}
+                        )
+                        total_csv_rows += df.height
+                        csv_cols = len(df.columns)
+                        frames.append(df)
+                    except Exception as e:
+                        logger.warning(
+                            f"[BRONZE] Failed to read {csv_paths[table_type]}: {e}"
+                        )
+
+                if not frames:
                     logger.warning(
-                        f"[BRONZE] Failed to read {csv_paths[table_type]}: {e}"
+                        f"[BRONZE] No data for {table_type}, skipping parquet write"
                     )
+                    audit[table_type] = {
+                        "csv_rows": 0,
+                        "csv_cols": 0,
+                        "parquet_rows": 0,
+                    }
+                    continue
 
-            if not frames:
-                logger.warning(
-                    f"[BRONZE] No data for {table_type}, skipping parquet write"
+                df_concat = pl.concat(frames)
+                staging_path = self._staging_path(fecha_vigencia, table_type)
+
+                logger.info(
+                    f"[BRONZE] Staging {table_type}.parquet: "
+                    f"{df_concat.height:,} rows -> s3://{staging_path}"
                 )
+
+                with self._open_output(staging_path) as out:
+                    pq.write_table(df_concat.to_arrow(), out, compression="zstd")
+
                 audit[table_type] = {
-                    "csv_rows": 0,
-                    "csv_cols": 0,
-                    "parquet_rows": 0,
+                    "csv_rows": total_csv_rows,
+                    "csv_cols": csv_cols,
+                    "parquet_rows": df_concat.height,
                 }
-                continue
+                staged.append(table_type)
 
-            df_concat = pl.concat(frames)
-            parquet_path = self._parquet_path(fecha_vigencia, table_type)
-
-            logger.info(
-                f"[BRONZE] Writing {table_type}.parquet: "
-                f"{df_concat.height:,} rows -> s3://{parquet_path}"
+            if set(staged) == set(TABLE_TYPES):
+                self._commit_day(fecha_vigencia)
+            else:
+                missing = [t for t in TABLE_TYPES if t not in staged]
+                logger.warning(
+                    f"[BRONZE] Incomplete day {fecha_vigencia}: "
+                    f"missing {missing}; not committing "
+                    f"(prior committed day left intact if any)"
+                )
+                self._cleanup_staging(fecha_vigencia)
+        except Exception:
+            # Leave final paths + _SUCCESS untouched; drop partial staging.
+            logger.error(
+                f"[BRONZE] Build failed for {fecha_vigencia}; "
+                "cleaning staging, prior committed day preserved"
             )
-
-            with self._s3.open_output_stream(parquet_path) as out:
-                pq.write_table(df_concat.to_arrow(), out, compression="zstd")
-
-            audit[table_type] = {
-                "csv_rows": total_csv_rows,
-                "csv_cols": csv_cols,
-                "parquet_rows": df_concat.height,
-            }
+            self._cleanup_staging(fecha_vigencia)
+            raise
 
         logger.info(f"[BRONZE] Parquet build complete for {fecha_vigencia}")
         return audit
 
-    def read_dimensions(
-        self, fecha_vigencia: date
-    ) -> Dict[str, pl.DataFrame]:
+    def read_dimensions(self, fecha_vigencia: date) -> Dict[str, pl.DataFrame]:
         """
         Read the small dimension tables (comercio, sucursales) eagerly.
 

--- a/src/sepa_pipeline/pipeline.py
+++ b/src/sepa_pipeline/pipeline.py
@@ -49,6 +49,7 @@ SCRAPER_DATA_DIR = "data"
 # Scraping
 # ---------------------------------------------------------------------------
 
+
 async def _scrape_date(target_date: date) -> bool:
     """Run the scraper for a single date. Returns True on success."""
     logger.info(f"Scraping data for {target_date}")
@@ -91,10 +92,12 @@ def _raw_zip_exists(config: SEPAConfig, target_date: date) -> bool:
 # Daily processing
 # ---------------------------------------------------------------------------
 
+
 def process_daily_data(
     target_date: date,
     config: SEPAConfig,
     targets: list[str],
+    force_rebuild_bronze: bool = False,
 ) -> None:
     """
     Full pipeline for one date:
@@ -103,6 +106,9 @@ def process_daily_data(
       3. Build bronze parquet (if not cached) + write audit
       4. Read from bronze parquet, validate, transform to silver
       5. Load to targets (iceberg, bigquery)
+
+    When ``force_rebuild_bronze`` is True, ignore the parquet cache and
+    re-extract / rebuild from the raw ZIP (scraping only if raw is missing).
     """
     logger.info(f"Starting SEPA pipeline for {target_date} | Targets: {targets}")
 
@@ -110,12 +116,17 @@ def process_daily_data(
     audit_writer = SEPAAuditWriter(config)
 
     # --- Step 1–2: Ensure bronze data exists ---
-    has_parquet = parquet_loader.exists(target_date)
+    has_parquet = parquet_loader.exists(target_date) and not force_rebuild_bronze
+
+    if force_rebuild_bronze:
+        logger.info(
+            f"[BRONZE] Force rebuild requested for {target_date} "
+            "(ignoring parquet cache)"
+        )
 
     if has_parquet:
         logger.info(
-            f"[BRONZE] Parquet cache hit for {target_date}, "
-            "skipping extraction"
+            f"[BRONZE] Parquet cache hit for {target_date}, skipping extraction"
         )
     else:
         # Need raw ZIP → check if it exists, scrape if not
@@ -139,7 +150,12 @@ def process_daily_data(
                 )
                 return
 
-            all_csv_paths, malformed_zips_count, stale_count, unknown_count = extractor.extract_all_zips(raw_zip_dir, target_date)
+            (
+                all_csv_paths,
+                malformed_zips_count,
+                stale_count,
+                unknown_count,
+            ) = extractor.extract_all_zips(raw_zip_dir, target_date)
 
             # Build parquet + audit
             audit_data = parquet_loader.build(all_csv_paths, target_date)
@@ -199,16 +215,10 @@ def process_daily_data(
         bigquery_loader.setup(target_date)
 
     if iceberg_loader:
-        iceberg_loader.load_comercios(
-            to_silver_comercios(df_comercios), target_date
-        )
-        iceberg_loader.load_sucursales(
-            to_silver_sucursales(df_sucursales), target_date
-        )
+        iceberg_loader.load_comercios(to_silver_comercios(df_comercios), target_date)
+        iceberg_loader.load_sucursales(to_silver_sucursales(df_sucursales), target_date)
     if bigquery_loader:
-        bigquery_loader.load_comercios(
-            to_silver_comercios(df_comercios), target_date
-        )
+        bigquery_loader.load_comercios(to_silver_comercios(df_comercios), target_date)
         bigquery_loader.load_sucursales(
             to_silver_sucursales(df_sucursales), target_date
         )
@@ -217,12 +227,8 @@ def process_daily_data(
     logger.info("Processing productos in batches")
     total_loaded = 0
 
-    for idx, chunk in enumerate(
-        parquet_loader.read_productos_batched(target_date)
-    ):
-        logger.info(
-            f"Processing batch {idx + 1}: {chunk.height:,} rows"
-        )
+    for idx, chunk in enumerate(parquet_loader.read_productos_batched(target_date)):
+        logger.info(f"Processing batch {idx + 1}: {chunk.height:,} rows")
 
         chunk = validator.validate_productos(chunk)
         _, chunk = validator.validate_referential_integrity(
@@ -265,6 +271,7 @@ def process_daily_data(
 # CLI
 # ---------------------------------------------------------------------------
 
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="SEPA Pipeline Runner")
 
@@ -302,6 +309,14 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Run Iceberg snapshot maintenance at the end of the pipeline",
     )
+    parser.add_argument(
+        "--force-rebuild-bronze",
+        action="store_true",
+        help=(
+            "Ignore bronze parquet cache and rebuild from raw ZIP "
+            "(re-scrape only if raw ZIP is missing)"
+        ),
+    )
 
     return parser.parse_args()
 
@@ -326,8 +341,7 @@ def _resolve_dates(args: argparse.Namespace) -> list[date]:
             logger.error("--date-from must be earlier than or equal to --date-to.")
             sys.exit(1)
         return [
-            date_from + timedelta(days=i)
-            for i in range((date_to - date_from).days + 1)
+            date_from + timedelta(days=i) for i in range((date_to - date_from).days + 1)
         ]
     elif args.date:
         return [_parse_date(args.date)]
@@ -343,8 +357,7 @@ if __name__ == "__main__":
 
     if args.scrape_only:
         logger.info(
-            f"Scrape-only mode | Dates: {dates[0]} to {dates[-1]} "
-            f"({len(dates)} day(s))"
+            f"Scrape-only mode | Dates: {dates[0]} to {dates[-1]} ({len(dates)} day(s))"
         )
         for target_date in dates:
             success = asyncio.run(_scrape_date(target_date))
@@ -358,7 +371,12 @@ if __name__ == "__main__":
             f"({len(dates)} day(s)) | Targets: {targets}"
         )
         for target_date in dates:
-            process_daily_data(target_date, config, targets)
+            process_daily_data(
+                target_date,
+                config,
+                targets,
+                force_rebuild_bronze=args.force_rebuild_bronze,
+            )
 
         if args.maintain_iceberg and "iceberg" in targets:
             logger.info("Running post-pipeline Iceberg maintenance...")

--- a/tests/test_parquet_loader.py
+++ b/tests/test_parquet_loader.py
@@ -1,0 +1,296 @@
+"""Tests for bronze ParquetLoader: exists, staging commit, force-rebuild semantics."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pyarrow.parquet as pq
+import pytest
+from pyarrow import fs
+
+from sepa_pipeline.loaders.parquet_loader import (
+    SUCCESS_MARKER,
+    TABLE_TYPES,
+    ParquetLoader,
+)
+
+
+FECHA = date(2026, 4, 4)
+
+
+@pytest.fixture
+def local_fs(tmp_path: Path) -> fs.SubTreeFileSystem:
+    """Filesystem rooted at tmp_path so S3-style keys map to local files."""
+    return fs.SubTreeFileSystem(str(tmp_path), fs.LocalFileSystem())
+
+
+@pytest.fixture
+def config() -> SimpleNamespace:
+    return SimpleNamespace(minio_bucket="sepa-lakehouse")
+
+
+@pytest.fixture
+def loader(config: SimpleNamespace, local_fs: fs.SubTreeFileSystem) -> ParquetLoader:
+    return ParquetLoader(config, filesystem=local_fs)  # type: ignore[arg-type]
+
+
+def _write_csv(path: Path, header: str, *rows: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(header + "\n" + "\n".join(rows) + "\n", encoding="utf-8")
+
+
+def _sample_csv_paths(tmp_path: Path) -> list[dict[str, Path]]:
+    """One child-ZIP worth of minimal CSVs for all three table types."""
+    base = tmp_path / "extract" / "child1"
+    comercio = base / "comercio.csv"
+    sucursales = base / "sucursales.csv"
+    productos = base / "productos.csv"
+
+    _write_csv(
+        comercio,
+        "id_comercio|comercio_cuit|comercio_razon_social",
+        "1|20123456789|Test SA",
+    )
+    _write_csv(
+        sucursales,
+        "id_comercio|id_bandera|id_sucursal|sucursales_nombre",
+        "1|1|10|Sucursal Centro",
+    )
+    _write_csv(
+        productos,
+        "id_comercio|id_bandera|id_sucursal|id_producto|productos_ean|"
+        "productos_descripcion|productos_precio_lista",
+        "1|1|10|SKU1|7790001|Leche 1L|1500.50",
+        "1|1|10|SKU2|7790002|Pan|800.00",
+    )
+    return [
+        {
+            "comercio": comercio,
+            "sucursales": sucursales,
+            "productos": productos,
+        }
+    ]
+
+
+def test_exists_false_when_empty(loader: ParquetLoader) -> None:
+    assert loader.exists(FECHA) is False
+
+
+def test_build_commits_and_exists(
+    loader: ParquetLoader,
+    local_fs: fs.SubTreeFileSystem,
+    tmp_path: Path,
+) -> None:
+    audit = loader.build(_sample_csv_paths(tmp_path), FECHA)
+
+    assert loader.exists(FECHA) is True
+    assert audit["comercio"]["parquet_rows"] == 1
+    assert audit["sucursales"]["parquet_rows"] == 1
+    assert audit["productos"]["parquet_rows"] == 2
+
+    # Final files + marker present; staging cleaned.
+    prefix = loader._parquet_prefix(FECHA)
+    for table in TABLE_TYPES:
+        assert loader._file_exists(f"{prefix}/{table}.parquet")
+        assert not loader._file_exists(f"{prefix}/.staging/{table}.parquet")
+    assert loader._file_exists(f"{prefix}/{SUCCESS_MARKER}")
+
+    dims = loader.read_dimensions(FECHA)
+    assert dims["comercio"].height == 1
+    assert dims["sucursales"].height == 1
+
+    productos = list(loader.read_productos_batched(FECHA, batch_size=1))
+    assert sum(df.height for df in productos) == 2
+
+
+def test_exists_requires_success_marker(
+    loader: ParquetLoader,
+    local_fs: fs.SubTreeFileSystem,
+    tmp_path: Path,
+) -> None:
+    loader.build(_sample_csv_paths(tmp_path), FECHA)
+    assert loader.exists(FECHA) is True
+
+    loader._delete_if_exists(loader._success_path(FECHA))
+    assert loader.exists(FECHA) is False
+
+
+def test_exists_false_if_one_table_missing(
+    loader: ParquetLoader,
+    tmp_path: Path,
+) -> None:
+    loader.build(_sample_csv_paths(tmp_path), FECHA)
+    loader._delete_if_exists(loader._parquet_path(FECHA, "productos"))
+    # Marker still present but incomplete → not a cache hit.
+    assert loader.exists(FECHA) is False
+
+
+def test_partial_build_does_not_commit(
+    loader: ParquetLoader,
+    tmp_path: Path,
+) -> None:
+    """Missing one table type → no _SUCCESS, no final files."""
+    paths = _sample_csv_paths(tmp_path)
+    # Only comercio + sucursales (simulate missing productos CSVs).
+    paths[0].pop("productos")
+
+    audit = loader.build(paths, FECHA)
+
+    assert audit["productos"]["parquet_rows"] == 0
+    assert loader.exists(FECHA) is False
+    for table in TABLE_TYPES:
+        assert not loader._file_exists(loader._parquet_path(FECHA, table))
+    assert not loader._file_exists(loader._success_path(FECHA))
+    # Staging cleaned after incomplete build.
+    for table in ("comercio", "sucursales"):
+        assert not loader._file_exists(loader._staging_path(FECHA, table))
+
+
+def test_failed_rebuild_preserves_committed_day(
+    loader: ParquetLoader,
+    tmp_path: Path,
+) -> None:
+    """After a good commit, a failed rebuild leaves the prior day intact."""
+    loader.build(_sample_csv_paths(tmp_path), FECHA)
+    assert loader.exists(FECHA) is True
+
+    original = {
+        t: pq.read_table(loader._parquet_path(FECHA, t), filesystem=loader._s3).num_rows
+        for t in TABLE_TYPES
+    }
+
+    # Force a failure while staging productos (pyarrow FS methods are read-only).
+    real_open = loader._open_output
+
+    def boom(path: str, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if path.endswith("productos.parquet") and ".staging" in path:
+            raise OSError("simulated staging failure")
+        return real_open(path, *args, **kwargs)
+
+    with patch.object(loader, "_open_output", side_effect=boom):
+        with pytest.raises(OSError, match="simulated staging failure"):
+            loader.build(_sample_csv_paths(tmp_path), FECHA)
+
+    # Prior committed day still a cache hit.
+    assert loader.exists(FECHA) is True
+    for table, rows in original.items():
+        table_data = pq.read_table(
+            loader._parquet_path(FECHA, table), filesystem=loader._s3
+        )
+        assert table_data.num_rows == rows
+
+    # Staging cleaned on failure.
+    for table in TABLE_TYPES:
+        assert not loader._file_exists(loader._staging_path(FECHA, table))
+
+
+def test_rebuild_overwrites_committed_day(
+    loader: ParquetLoader,
+    tmp_path: Path,
+) -> None:
+    loader.build(_sample_csv_paths(tmp_path), FECHA)
+
+    # Second build with extra productos row.
+    paths = _sample_csv_paths(tmp_path)
+    extra = paths[0]["productos"]
+    content = extra.read_text(encoding="utf-8").rstrip("\n")
+    extra.write_text(
+        content + "\n1|1|10|SKU3|7790003|Yerba|2000.00\n",
+        encoding="utf-8",
+    )
+
+    audit = loader.build(paths, FECHA)
+    assert loader.exists(FECHA) is True
+    assert audit["productos"]["parquet_rows"] == 3
+
+    rows = sum(df.height for df in loader.read_productos_batched(FECHA, batch_size=10))
+    assert rows == 3
+
+
+def test_force_rebuild_pipeline_skips_cache(
+    config: SimpleNamespace,
+    local_fs: fs.SubTreeFileSystem,
+    tmp_path: Path,
+) -> None:
+    """process_daily_data with force_rebuild_bronze ignores exists() hit."""
+    from sepa_pipeline import pipeline as pipeline_mod
+
+    loader = ParquetLoader(config, filesystem=local_fs)  # type: ignore[arg-type]
+    loader.build(_sample_csv_paths(tmp_path), FECHA)
+    assert loader.exists(FECHA) is True
+
+    build_calls: list[date] = []
+
+    def fake_build(self, all_csv_paths, fecha_vigencia):  # type: ignore[no-untyped-def]
+        build_calls.append(fecha_vigencia)
+        return {
+            t: {"csv_rows": 0, "csv_cols": 0, "parquet_rows": 0} for t in TABLE_TYPES
+        }
+
+    class FakeExtractor:
+        def fetch_from_bronze(self, target_date, config):  # type: ignore[no-untyped-def]
+            return tmp_path / "raw"
+
+        def extract_all_zips(self, raw_zip_dir, target_date):  # type: ignore[no-untyped-def]
+            return _sample_csv_paths(tmp_path), 0, 0, 0
+
+    (tmp_path / "raw").mkdir(exist_ok=True)
+
+    with (
+        patch.object(pipeline_mod, "ParquetLoader", return_value=loader),
+        patch.object(pipeline_mod, "SEPAExtractor", FakeExtractor),
+        patch.object(pipeline_mod, "_raw_zip_exists", return_value=True),
+        patch.object(ParquetLoader, "build", fake_build),
+        patch.object(pipeline_mod, "SEPAAuditWriter") as mock_audit_cls,
+        patch.object(pipeline_mod, "SEPAValidator") as mock_validator_cls,
+        patch.object(pipeline_mod, "IcebergLoader", return_value=None),
+        patch.object(pipeline_mod, "BigQueryLoader", return_value=None),
+    ):
+        mock_audit = mock_audit_cls.return_value
+        mock_validator = mock_validator_cls.return_value
+        mock_validator.validate_comercio.side_effect = lambda df: df
+        mock_validator.validate_sucursales.side_effect = lambda df: df
+        mock_validator.validate_referential_integrity.side_effect = lambda c, s, p: (
+            s,
+            p,
+        )
+        mock_validator.validate_productos.side_effect = lambda df: df
+        mock_validator.get_drop_stats.return_value = {
+            "validation_dropped": 0,
+            "integrity_dropped": 0,
+            "negative_price_count": 0,
+        }
+
+        # Without force: cache hit → build not called.
+        pipeline_mod.process_daily_data(
+            FECHA,
+            config,
+            targets=[],
+            force_rebuild_bronze=False,  # type: ignore[arg-type]
+        )
+        assert build_calls == []
+
+        # With force: rebuild path runs build.
+        pipeline_mod.process_daily_data(
+            FECHA,
+            config,
+            targets=[],
+            force_rebuild_bronze=True,  # type: ignore[arg-type]
+        )
+        assert build_calls == [FECHA]
+        mock_audit.write_bronze.assert_called_once()
+
+
+def test_cli_force_rebuild_bronze_flag() -> None:
+    from sepa_pipeline.pipeline import parse_args
+
+    with patch(
+        "sys.argv",
+        ["pipeline", "--force-rebuild-bronze", "--date", "2026-04-04"],
+    ):
+        args = parse_args()
+    assert args.force_rebuild_bronze is True
+    assert args.date == "2026-04-04"


### PR DESCRIPTION
## Summary

Implements [SEP-277](https://linear.app/sepa/issue/SEP-277): make bronze parquet materialization re-run safe without manual MinIO surgery.

- **Atomic day write**: tables are written under `bronze/parquet/.../.staging/`, then stream-copied to final keys only when all three (`comercio`, `sucursales`, `productos`) succeed; `_SUCCESS` is written last.
- **Safe cache**: `exists()` requires `_SUCCESS` **and** all three parquet files, so incomplete or mid-commit days are never treated as cache hits.
- **Failure behavior**: staging is cleaned on error; a previously committed day is left intact. `_SUCCESS` is removed before overwrite so a mid-rebuild never looks complete.
- **CLI**: `--force-rebuild-bronze` ignores the parquet cache and rebuilds from the raw ZIP (scrapes only if raw is missing).
- **Tests**: `tests/test_parquet_loader.py` covers exists/marker, partial build, failed rebuild preserves prior day, force path, and CLI flag.

Verified with a full scrape + Iceberg load for `2026-07-10` on this branch (staging → commit → `_SUCCESS` → silver load).

## Out of scope

- Streaming bronze productos to lower peak RAM (**SEP-278**)
- Iceberg small-file compaction / larger silver writers (**SEP-274** and follow-ups)

## Test plan

- [x] `uv run pytest tests/ -v` (incl. new parquet loader tests)
- [x] `uv run ruff check` / format on touched files
- [x] Live: scrape `--date 2026-07-10` then pipeline `--target iceberg`
- [x] Optional: re-run same date without force → bronze cache hit (skip extract)
- [x] Optional: re-run with `--force-rebuild-bronze` → rebuild + new `_SUCCESS`