### PR TITLE
[SEP-278]: Stream bronze parquet write + buffer precios appends

### DIFF
--- a/src/sepa_pipeline/loaders/base.py
+++ b/src/sepa_pipeline/loaders/base.py
@@ -9,6 +9,11 @@ from ..config import SEPAConfig
 
 logger = get_logger(__name__)
 
+# Buffer precios appends so each Iceberg data file is closer to the recommended
+# 128–256 MB range. ~2M rows is a practical tradeoff: far fewer UUID files than
+# per-500k appends, without materializing the full ~12M-row day in RAM.
+PRECIOS_APPEND_TARGET_ROWS = 2_000_000
+
 
 class BaseLoader(ABC):
     """
@@ -27,6 +32,10 @@ class BaseLoader(ABC):
         """
         self.config = config
         self.stage_name = self.__class__.__name__
+        self._precios_buffer: list[pl.DataFrame] = []
+        self._precios_buffer_rows: int = 0
+        self._precios_append_target_rows: int = PRECIOS_APPEND_TARGET_ROWS
+        self._productos_buffer: list[pl.DataFrame] = []
 
     @abstractmethod
     def setup(self, fecha_vigencia: date) -> None:
@@ -67,11 +76,15 @@ class BaseLoader(ABC):
         """Load productos dimension data. Default no-op."""
         pass
 
-    def log_start(self, fecha_vigencia: date):
+    def flush(self, fecha_vigencia: date) -> None:
+        """Flush any buffered fact-table chunks. Default no-op."""
+        pass
+
+    def log_start(self, fecha_vigencia: date) -> None:
         """Log the start of a loading process."""
         logger.info(f"[{self.stage_name}] Starting load for {fecha_vigencia}")
 
-    def log_success(self, fecha_vigencia: date, rows: int):
+    def log_success(self, fecha_vigencia: date, rows: int) -> None:
         """Log the successful completion of a loading process."""
         logger.info(
             f"[{self.stage_name}] Successfully loaded {rows} rows for {fecha_vigencia}"

--- a/src/sepa_pipeline/loaders/bigquery_loader.py
+++ b/src/sepa_pipeline/loaders/bigquery_loader.py
@@ -26,6 +26,7 @@ class BigQueryLoader(BaseLoader):
         # Workaround for BigQuery mapping null parent-snapshot-ids to strings instead of ints
         # BigQueryMetastoreCatalog checks the GLOBAL config for this property, not the catalog properties.
         import os
+
         os.environ["PYICEBERG_LEGACY_CURRENT_SNAPSHOT_ID"] = "True"
 
         # BigQuery datasets serve as namespaces. Use the one configured.
@@ -82,6 +83,9 @@ class BigQueryLoader(BaseLoader):
 
         # Clear seen products for the new load
         self._seen_productos.clear()
+        self._precios_buffer.clear()
+        self._precios_buffer_rows = 0
+        self._productos_buffer.clear()
 
     def _cleanup_dimension_table(self, table_name: str, fecha_vigencia: date) -> None:
         if not self.catalog:
@@ -153,19 +157,10 @@ class BigQueryLoader(BaseLoader):
         except Exception as e:
             logger.warning(f"[BIGQUERY] Failed to upgrade format-version: {e}")
 
-    def load(self, df: pl.DataFrame, fecha_vigencia: date) -> None:
-        """
-        Append a chunk of data into the BigQuery Iceberg table.
-        """
-        self.log_start(fecha_vigencia)
-
-        if not self.catalog:
-            logger.warning(
-                "[BIGQUERY] Skipping BigQuery append (catalog not initialized)"
-            )
-            return
-
-        # Ensure fecha_vigencia and scraped_at are present
+    def _prepare_precios_df(
+        self, df: pl.DataFrame, fecha_vigencia: date
+    ) -> pl.DataFrame:
+        """Inject fecha_vigencia / scraped_at so append schema is stable."""
         cols_to_add = []
         if "scraped_at" not in df.columns:
             cols_to_add.append(pl.lit(datetime.now()).alias("scraped_at"))
@@ -179,22 +174,68 @@ class BigQueryLoader(BaseLoader):
 
         if cols_to_add:
             df = df.with_columns(cols_to_add)
+        return df
 
+    def _append_precios(self, df: pl.DataFrame, fecha_vigencia: date) -> None:
+        """Write one buffered chunk to the fact table (one data-file batch)."""
+        if df.is_empty():
+            return
         self._ensure_iceberg_table(df)
-
-        if self._iceberg_table:
-            logger.info(f"[BIGQUERY] Appending {len(df)} rows to BigLake table...")
-            self._iceberg_table.append(df.to_arrow())
-            self.log_success(fecha_vigencia, len(df))
-        else:
+        if not self._iceberg_table:
             logger.error(
                 "[BIGQUERY] Failed to load/create BigQuery table, skipping append"
             )
+            return
+        logger.info(f"[BIGQUERY] Appending {len(df):,} rows to BigLake table...")
+        self._iceberg_table.append(df.to_arrow())
+        self.log_success(fecha_vigencia, len(df))
 
-    def _ensure_dimension_table(self, table_name: str, df: pl.DataFrame) -> Table | None:
+    def load(self, df: pl.DataFrame, fecha_vigencia: date) -> None:
+        """
+        Buffer a precios chunk and append when the target row count is reached.
+
+        Same strategy as IcebergLoader: fewer, larger data files without holding
+        the full day in memory.
+        """
+        if not self.catalog:
+            logger.warning(
+                "[BIGQUERY] Skipping BigQuery append (catalog not initialized)"
+            )
+            return
+        if df.is_empty():
+            return
+
+        df = self._prepare_precios_df(df, fecha_vigencia)
+        self._precios_buffer.append(df)
+        self._precios_buffer_rows += len(df)
+
+        if self._precios_buffer_rows >= self._precios_append_target_rows:
+            self.flush(fecha_vigencia)
+
+    def flush(self, fecha_vigencia: date) -> None:
+        """Append any remaining buffered fact and dimension rows."""
+        if self._precios_buffer:
+            combined = pl.concat(self._precios_buffer)
+            self._precios_buffer.clear()
+            self._precios_buffer_rows = 0
+            self._append_precios(combined, fecha_vigencia)
+
+        if self._productos_buffer:
+            combined_prod = pl.concat(self._productos_buffer)
+            self._productos_buffer.clear()
+            table = self._ensure_dimension_table("dim_productos", combined_prod)
+            if table:
+                logger.info(
+                    f"[BIGQUERY] Appending {len(combined_prod):,} rows to dim_productos..."
+                )
+                table.append(combined_prod.to_arrow())
+
+    def _ensure_dimension_table(
+        self, table_name: str, df: pl.DataFrame
+    ) -> Table | None:
         if not self.catalog:
             return None
-        
+
         identifier = f"{self._namespace}.{table_name}"
         if identifier in self._dim_tables:
             return self._dim_tables[identifier]
@@ -224,7 +265,9 @@ class BigQueryLoader(BaseLoader):
                 self._dim_tables[identifier] = table
                 return table
             except Exception as e:
-                logger.error(f"[BIGQUERY] Failed to create dimension table {identifier}: {e}")
+                logger.error(
+                    f"[BIGQUERY] Failed to create dimension table {identifier}: {e}"
+                )
                 return None
 
     def _prepare_dim_df(self, df: pl.DataFrame, fecha_vigencia: date) -> pl.DataFrame:
@@ -256,15 +299,19 @@ class BigQueryLoader(BaseLoader):
     def load_productos(self, df: pl.DataFrame, fecha_vigencia: date) -> None:
         if not self.catalog or df.is_empty():
             return
-        
+
         # Ensure the chunk itself only has unique products before checking against history
         df_unique = df.unique(subset=["id_producto"])
-        
+
         # Filter out products we've already seen today
-        new_products = df_unique.filter(~pl.col("id_producto").is_in(list(self._seen_productos)))
-        
+        new_products = df_unique.filter(
+            ~pl.col("id_producto").is_in(list(self._seen_productos))
+        )
+
         if new_products.is_empty():
-            logger.debug("[BIGQUERY] No new products to append to dim_productos in this chunk.")
+            logger.debug(
+                "[BIGQUERY] No new products to append to dim_productos in this chunk."
+            )
             return
 
         # Update seen products
@@ -272,7 +319,4 @@ class BigQueryLoader(BaseLoader):
         self._seen_productos.update(new_ids)
 
         new_products = self._prepare_dim_df(new_products, fecha_vigencia)
-        table = self._ensure_dimension_table("dim_productos", new_products)
-        if table:
-            logger.info(f"[BIGQUERY] Appending {len(new_products)} rows to dim_productos...")
-            table.append(new_products.to_arrow())
+        self._productos_buffer.append(new_products)

--- a/src/sepa_pipeline/loaders/iceberg_loader.py
+++ b/src/sepa_pipeline/loaders/iceberg_loader.py
@@ -15,6 +15,7 @@ logger = get_logger(__name__)
 # S3_ENDPOINT key as used by PyIceberg's FsspecFileIO
 _S3_ENDPOINT_KEY = "s3.endpoint"
 
+
 class IcebergLoader(BaseLoader):
     """
     Loader for Apache Iceberg tables stored in S3/MinIO using PyIceberg.
@@ -93,8 +94,11 @@ class IcebergLoader(BaseLoader):
         for dim_table in ["dim_comercios", "dim_sucursales", "dim_productos"]:
             self._cleanup_dimension_table(dim_table, fecha_vigencia)
 
-        # Clear seen products for the new load
+        # Clear seen products and any leftover precios buffer for the new load
         self._seen_productos.clear()
+        self._precios_buffer.clear()
+        self._precios_buffer_rows = 0
+        self._productos_buffer.clear()
 
     def _cleanup_dimension_table(self, table_name: str, fecha_vigencia: date) -> None:
         if not self.catalog:
@@ -116,15 +120,21 @@ class IcebergLoader(BaseLoader):
             return
 
         if not self.catalog:
-            logger.error("[ICEBERG] Iceberg catalog not initialized, cannot create table")
+            logger.error(
+                "[ICEBERG] Iceberg catalog not initialized, cannot create table"
+            )
             return
 
         try:
             self._iceberg_table = self.catalog.load_table(self._table_identifier)
             self._fix_io_endpoint(self._iceberg_table)
-            logger.info(f"[ICEBERG] Loaded existing Iceberg table: {self._table_identifier}")
+            logger.info(
+                f"[ICEBERG] Loaded existing Iceberg table: {self._table_identifier}"
+            )
         except NoSuchTableError:
-            logger.info(f"[ICEBERG] Iceberg table {self._table_identifier} not found, creating from schema...")
+            logger.info(
+                f"[ICEBERG] Iceberg table {self._table_identifier} not found, creating from schema..."
+            )
 
             arrow_table = df.to_arrow()
 
@@ -140,7 +150,9 @@ class IcebergLoader(BaseLoader):
                 schema=arrow_table.schema,
             )
             self._fix_io_endpoint(self._iceberg_table)
-            logger.info(f"[ICEBERG] Created base Iceberg table: {self._table_identifier}")
+            logger.info(
+                f"[ICEBERG] Created base Iceberg table: {self._table_identifier}"
+            )
 
             # 2. Update Partition Spec: Day(fecha_vigencia)
             try:
@@ -154,55 +166,86 @@ class IcebergLoader(BaseLoader):
             except Exception as e:
                 logger.error(f"[ICEBERG] Failed to set partition spec: {e}")
 
-    def load(self, df: pl.DataFrame, fecha_vigencia: date) -> None:
-        """
-        Append a chunk of data into the Iceberg table.
-        """
-        self.log_start(fecha_vigencia)
-
-        if not self.catalog:
-            logger.warning("[ICEBERG] Skipping Iceberg append (catalog not initialized)")
-            return
-
-        # Use the scraped_at defined in the dataframe if it's there, otherwise datetime.now()
-        # Ensure it is naive (without timezone) as the Iceberg schema was created assuming naive timestamps
-        if "scraped_at" not in df.columns:
-            scraped_at_naive = datetime.now()
-        else:
-            # Grab the first element and parse it, or let polars handle timezone stripping
-            # Typically pipeline.py will pass a timestamptz that might need to be naive.
-            # Easiest way in polars: cast to Datetime without timezone
-            # But normally we just inject it if missing, or strip it if present.
-            pass
-
-        # Ensure fecha_vigencia and scraped_at are present
+    def _prepare_precios_df(
+        self, df: pl.DataFrame, fecha_vigencia: date
+    ) -> pl.DataFrame:
+        """Inject fecha_vigencia / scraped_at so append schema is stable."""
         cols_to_add = []
         if "scraped_at" not in df.columns:
-             cols_to_add.append(pl.lit(datetime.now()).alias("scraped_at"))
+            cols_to_add.append(pl.lit(datetime.now()).alias("scraped_at"))
         else:
-             # strip timezone from existing column just in case to match legacy behavior
-             cols_to_add.append(pl.col("scraped_at").dt.replace_time_zone(None).alias("scraped_at"))
+            # Strip timezone to match legacy Iceberg schema (naive timestamps).
+            cols_to_add.append(
+                pl.col("scraped_at").dt.replace_time_zone(None).alias("scraped_at")
+            )
 
         if "fecha_vigencia" not in df.columns:
-             cols_to_add.append(pl.lit(fecha_vigencia).alias("fecha_vigencia"))
+            cols_to_add.append(pl.lit(fecha_vigencia).alias("fecha_vigencia"))
 
         if cols_to_add:
             df = df.with_columns(cols_to_add)
+        return df
 
-        # Ensure table exists (lazy load via first chunk)
+    def _append_precios(self, df: pl.DataFrame, fecha_vigencia: date) -> None:
+        """Write one buffered chunk to the fact table (one data-file batch)."""
+        if df.is_empty():
+            return
         self._ensure_iceberg_table(df)
+        if not self._iceberg_table:
+            logger.error(
+                "[ICEBERG] Failed to load/create Iceberg table, skipping append"
+            )
+            return
+        logger.info(f"[ICEBERG] Appending {len(df):,} rows to Iceberg table...")
+        self._iceberg_table.append(df.to_arrow())
+        self.log_success(fecha_vigencia, len(df))
 
-        if self._iceberg_table:
-            logger.info(f"[ICEBERG] Appending {len(df)} rows to Iceberg table...")
-            self._iceberg_table.append(df.to_arrow())
-            self.log_success(fecha_vigencia, len(df))
-        else:
-            logger.error("[ICEBERG] Failed to load/create Iceberg table, skipping append")
+    def load(self, df: pl.DataFrame, fecha_vigencia: date) -> None:
+        """
+        Buffer a precios chunk and append when the target row count is reached.
 
-    def _ensure_dimension_table(self, table_name: str, df: pl.DataFrame) -> Table | None:
+        Buffering produces fewer, larger data files than per-batch appends while
+        still avoiding a full-day in-memory materialization.
+        """
+        if not self.catalog:
+            logger.warning(
+                "[ICEBERG] Skipping Iceberg append (catalog not initialized)"
+            )
+            return
+        if df.is_empty():
+            return
+
+        df = self._prepare_precios_df(df, fecha_vigencia)
+        self._precios_buffer.append(df)
+        self._precios_buffer_rows += len(df)
+
+        if self._precios_buffer_rows >= self._precios_append_target_rows:
+            self.flush(fecha_vigencia)
+
+    def flush(self, fecha_vigencia: date) -> None:
+        """Append any remaining buffered fact and dimension rows."""
+        if self._precios_buffer:
+            combined = pl.concat(self._precios_buffer)
+            self._precios_buffer.clear()
+            self._precios_buffer_rows = 0
+            self._append_precios(combined, fecha_vigencia)
+
+        if self._productos_buffer:
+            combined_prod = pl.concat(self._productos_buffer)
+            self._productos_buffer.clear()
+            table = self._ensure_dimension_table("dim_productos", combined_prod)
+            if table:
+                logger.info(
+                    f"[ICEBERG] Appending {len(combined_prod):,} rows to dim_productos..."
+                )
+                table.append(combined_prod.to_arrow())
+
+    def _ensure_dimension_table(
+        self, table_name: str, df: pl.DataFrame
+    ) -> Table | None:
         if not self.catalog:
             return None
-        
+
         identifier = f"sepa.{table_name}"
         if identifier in self._dim_tables:
             return self._dim_tables[identifier]
@@ -235,7 +278,9 @@ class IcebergLoader(BaseLoader):
                 self._dim_tables[identifier] = table
                 return table
             except Exception as e:
-                logger.error(f"[ICEBERG] Failed to create dimension table {identifier}: {e}")
+                logger.error(
+                    f"[ICEBERG] Failed to create dimension table {identifier}: {e}"
+                )
                 return None
 
     def _prepare_dim_df(self, df: pl.DataFrame, fecha_vigencia: date) -> pl.DataFrame:
@@ -267,15 +312,19 @@ class IcebergLoader(BaseLoader):
     def load_productos(self, df: pl.DataFrame, fecha_vigencia: date) -> None:
         if not self.catalog or df.is_empty():
             return
-        
+
         # Ensure the chunk itself only has unique products before checking against history
         df_unique = df.unique(subset=["id_producto"])
-        
+
         # Filter out products we've already seen today
-        new_products = df_unique.filter(~pl.col("id_producto").is_in(list(self._seen_productos)))
-        
+        new_products = df_unique.filter(
+            ~pl.col("id_producto").is_in(list(self._seen_productos))
+        )
+
         if new_products.is_empty():
-            logger.debug("[ICEBERG] No new products to append to dim_productos in this chunk.")
+            logger.debug(
+                "[ICEBERG] No new products to append to dim_productos in this chunk."
+            )
             return
 
         # Update seen products
@@ -283,8 +332,4 @@ class IcebergLoader(BaseLoader):
         self._seen_productos.update(new_ids)
 
         new_products = self._prepare_dim_df(new_products, fecha_vigencia)
-        table = self._ensure_dimension_table("dim_productos", new_products)
-        if table:
-            logger.info(f"[ICEBERG] Appending {len(new_products)} rows to dim_productos...")
-            table.append(new_products.to_arrow())
-
+        self._productos_buffer.append(new_products)

--- a/src/sepa_pipeline/loaders/parquet_loader.py
+++ b/src/sepa_pipeline/loaders/parquet_loader.py
@@ -2,8 +2,12 @@
 Bronze Parquet Layer — Materializes raw CSV data as Parquet on MinIO.
 
 Reads all child ZIP CSVs (comercio, sucursales, productos) extracted from the
-daily master ZIP, concatenates each table type, and writes a single Parquet
-file per table per date to bronze/parquet/.
+daily master ZIP and writes a single Parquet file per table per date to
+bronze/parquet/.
+
+Productos (the large fact-like table) is staged with a streaming ParquetWriter:
+each child CSV is read, written as a row group, then freed — avoiding a full
+in-memory concat of ~12–15M rows.
 
 Writes are staged under ``.staging/`` and committed only when all three tables
 succeed, then a ``_SUCCESS`` marker is written. ``exists()`` requires the
@@ -17,9 +21,10 @@ from __future__ import annotations
 
 from datetime import date
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, Iterator, List
 
 import polars as pl
+import pyarrow as pa
 import pyarrow.parquet as pq
 from pyarrow import fs
 
@@ -156,13 +161,126 @@ class ParquetLoader:
             f"[BRONZE] Day {fecha_vigencia} committed ({SUCCESS_MARKER} written)"
         )
 
+    def _read_csv_frame(
+        self, path: Path, schema: Dict[str, type[pl.DataType]]
+    ) -> pl.DataFrame | None:
+        """Read one pipe-delimited SEPA CSV; return None on failure."""
+        try:
+            df = pl.read_csv(
+                path,
+                separator="|",
+                encoding="utf8-lossy",
+                has_header=True,
+                null_values=["", "NULL", "null"],
+                schema_overrides=schema,
+                truncate_ragged_lines=True,
+                ignore_errors=True,
+                quote_char=None,
+            )
+            return df.rename({col: col.lstrip("\ufeff").strip() for col in df.columns})
+        except Exception as e:
+            logger.warning(f"[BRONZE] Failed to read {path}: {e}")
+            return None
+
+    def _iter_table_frames(
+        self,
+        all_csv_paths: List[Dict[str, Path]],
+        table_type: str,
+    ) -> Iterator[pl.DataFrame]:
+        """Yield one DataFrame per child-ZIP CSV for ``table_type``."""
+        schema = get_schema_dict(table_type)
+        for csv_paths in all_csv_paths:
+            if table_type not in csv_paths:
+                continue
+            df = self._read_csv_frame(csv_paths[table_type], schema)
+            if df is not None and df.height > 0:
+                yield df
+
+    @staticmethod
+    def _align_to_columns(df: pl.DataFrame, columns: list[str]) -> pl.DataFrame:
+        """Reorder / pad columns so every batch matches the first frame's schema."""
+        missing = [c for c in columns if c not in df.columns]
+        if missing:
+            df = df.with_columns([pl.lit(None).alias(c) for c in missing])
+        return df.select(columns)
+
+    def _stage_table_streamed(
+        self,
+        table_type: str,
+        all_csv_paths: List[Dict[str, Path]],
+        fecha_vigencia: date,
+    ) -> Dict[str, int]:
+        """
+        Stream child CSVs into a single staged parquet via ParquetWriter.
+
+        Peak memory is roughly one child-ZIP frame (not the full day concat).
+        Still produces one unified ``{table_type}.parquet`` after commit.
+        """
+        staging_path = self._staging_path(fecha_vigencia, table_type)
+        writer: pq.ParquetWriter | None = None
+        output: Any | None = None
+        column_names: list[str] | None = None
+        arrow_schema: pa.Schema | None = None
+        total_csv_rows = 0
+        csv_cols = 0
+        frames_written = 0
+
+        try:
+            for df in self._iter_table_frames(all_csv_paths, table_type):
+                if writer is None:
+                    column_names = list(df.columns)
+                    csv_cols = len(column_names)
+                    arrow_table = df.to_arrow()
+                    arrow_schema = arrow_table.schema
+                    output = self._open_output(staging_path)
+                    writer = pq.ParquetWriter(
+                        output,
+                        arrow_schema,
+                        compression="zstd",
+                    )
+                    writer.write_table(arrow_table)
+                else:
+                    assert column_names is not None
+                    aligned = self._align_to_columns(df, column_names)
+                    # Cast to the writer's schema so column types stay stable.
+                    table = aligned.to_arrow()
+                    if arrow_schema is not None:
+                        table = table.cast(arrow_schema)
+                    writer.write_table(table)
+
+                total_csv_rows += df.height
+                frames_written += 1
+                del df
+
+            if writer is None:
+                logger.warning(
+                    f"[BRONZE] No data for {table_type}, skipping parquet write"
+                )
+                return {"csv_rows": 0, "csv_cols": 0, "parquet_rows": 0}
+
+            logger.info(
+                f"[BRONZE] Staging {table_type}.parquet (streamed): "
+                f"{total_csv_rows:,} rows from {frames_written} CSV(s) "
+                f"-> s3://{staging_path}"
+            )
+            return {
+                "csv_rows": total_csv_rows,
+                "csv_cols": csv_cols,
+                "parquet_rows": total_csv_rows,
+            }
+        finally:
+            if writer is not None:
+                writer.close()
+            elif output is not None:
+                output.close()
+
     def build(
         self,
         all_csv_paths: List[Dict[str, Path]],
         fecha_vigencia: date,
     ) -> Dict[str, Dict]:
         """
-        Read all extracted CSVs, concatenate by table type, write Parquet to MinIO.
+        Read all extracted CSVs and write Parquet to MinIO (streamed staging).
 
         Files are written under ``.staging/`` first. Only when all three tables
         stage successfully are they promoted to the day prefix and ``_SUCCESS``
@@ -188,66 +306,12 @@ class ParquetLoader:
 
         try:
             for table_type in TABLE_TYPES:
-                schema = get_schema_dict(table_type)
-
-                frames: list[pl.DataFrame] = []
-                total_csv_rows = 0
-                csv_cols = 0
-
-                for csv_paths in all_csv_paths:
-                    if table_type not in csv_paths:
-                        continue
-                    try:
-                        df = pl.read_csv(
-                            csv_paths[table_type],
-                            separator="|",
-                            encoding="utf8-lossy",
-                            has_header=True,
-                            null_values=["", "NULL", "null"],
-                            schema_overrides=schema,
-                            truncate_ragged_lines=True,
-                            ignore_errors=True,
-                            quote_char=None,
-                        )
-                        df = df.rename(
-                            {col: col.lstrip("\ufeff").strip() for col in df.columns}
-                        )
-                        total_csv_rows += df.height
-                        csv_cols = len(df.columns)
-                        frames.append(df)
-                    except Exception as e:
-                        logger.warning(
-                            f"[BRONZE] Failed to read {csv_paths[table_type]}: {e}"
-                        )
-
-                if not frames:
-                    logger.warning(
-                        f"[BRONZE] No data for {table_type}, skipping parquet write"
-                    )
-                    audit[table_type] = {
-                        "csv_rows": 0,
-                        "csv_cols": 0,
-                        "parquet_rows": 0,
-                    }
-                    continue
-
-                df_concat = pl.concat(frames)
-                staging_path = self._staging_path(fecha_vigencia, table_type)
-
-                logger.info(
-                    f"[BRONZE] Staging {table_type}.parquet: "
-                    f"{df_concat.height:,} rows -> s3://{staging_path}"
+                meta = self._stage_table_streamed(
+                    table_type, all_csv_paths, fecha_vigencia
                 )
-
-                with self._open_output(staging_path) as out:
-                    pq.write_table(df_concat.to_arrow(), out, compression="zstd")
-
-                audit[table_type] = {
-                    "csv_rows": total_csv_rows,
-                    "csv_cols": csv_cols,
-                    "parquet_rows": df_concat.height,
-                }
-                staged.append(table_type)
+                audit[table_type] = meta
+                if meta["parquet_rows"] > 0:
+                    staged.append(table_type)
 
             if set(staged) == set(TABLE_TYPES):
                 self._commit_day(fecha_vigencia)
@@ -284,7 +348,7 @@ class ParquetLoader:
             path = self._parquet_path(fecha_vigencia, table_type)
             logger.info(f"[BRONZE] Reading s3://{path}")
             table = pq.read_table(path, filesystem=self._s3)
-            result[table_type] = pl.from_arrow(table)
+            result[table_type] = pl.DataFrame(pl.from_arrow(table))
 
         return result
 
@@ -292,7 +356,7 @@ class ParquetLoader:
         self,
         fecha_vigencia: date,
         batch_size: int = 500_000,
-    ):
+    ) -> Iterator[pl.DataFrame | pl.Series]:
         """
         Yield productos parquet in batches to keep memory bounded.
 
@@ -309,6 +373,8 @@ class ParquetLoader:
         parquet_file = pq.ParquetFile(self._s3.open_input_file(path))
 
         for batch in parquet_file.iter_batches(batch_size=batch_size):
-            df = pl.from_arrow(batch)
+            ## added pl.DataFrame() wrapper to avoid typing issues
+            ## as stated in pl.from_arrow docstrings
+            df = pl.DataFrame(pl.from_arrow(batch))
             if df.height > 0:
                 yield df

--- a/src/sepa_pipeline/pipeline.py
+++ b/src/sepa_pipeline/pipeline.py
@@ -250,6 +250,12 @@ def process_daily_data(
 
         total_loaded += chunk.height
 
+    # Flush buffered precios so the last partial target-size window is written.
+    if iceberg_loader:
+        iceberg_loader.flush(target_date)
+    if bigquery_loader:
+        bigquery_loader.flush(target_date)
+
     drop_stats = validator.get_drop_stats()
     drop_stats["silver_loaded"] = total_loaded
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -39,7 +39,7 @@ def _write_csv_with_footer(df: pl.DataFrame, is_stale: bool, target_date: str) -
     csv_str = df.write_csv()
     csv_bytes = csv_str.encode("utf-8") if isinstance(csv_str, str) else csv_str
 
-    
+
     # Add SEPA footer
     date_to_write = target_date
     if is_stale:
@@ -48,7 +48,7 @@ def _write_csv_with_footer(df: pl.DataFrame, is_stale: bool, target_date: str) -
         import datetime as dt_module
         stale_dt = dt - dt_module.timedelta(days=2)
         date_to_write = stale_dt.strftime("%Y-%m-%d")
-        
+
     footer = f"\nUltima actualizacion: {date_to_write}".encode("utf-8")
     return csv_bytes + footer
 
@@ -67,19 +67,19 @@ def make_sepa_zip(
     with zipfile.ZipFile(outer_buf, "w", zipfile.ZIP_DEFLATED) as outer:
 
         stale_threshold = n_nested_zips // 2 + 1 if stale_majority else 0
-        
+
         for i in range(n_nested_zips):
             nested_name = f"sepa_1_comercio-sepa-{i}_{target_date}_01-01-01.zip"
-            
+
             if corrupt_nested and i == 0:
                 # Corrupt the first nested zip
                 outer.writestr(nested_name, b"this is not a zip")
                 continue
-                
+
             nested_buf = io.BytesIO()
             with zipfile.ZipFile(nested_buf, "w") as nested:
                 is_stale = i < stale_threshold
-                
+
                 # Write comercio
                 if not (missing_csv and i == 0):
                     df_comercio = make_comercio_df(1)
@@ -87,17 +87,17 @@ def make_sepa_zip(
                         f"comercio.csv",
                         _write_csv_with_footer(df_comercio, is_stale, target_date)
                     )
-                
+
                 # Write sucursales
                 df_sucursales = make_sucursales_df(1)
                 sucursales_csv = df_sucursales.write_csv()
                 nested.writestr("sucursales.csv", sucursales_csv.encode("utf-8") if isinstance(sucursales_csv, str) else sucursales_csv)
-                
+
                 # Write productos
                 df_productos = make_productos_df(n_productos)
                 productos_csv = df_productos.write_csv()
                 nested.writestr("productos.csv", productos_csv.encode("utf-8") if isinstance(productos_csv, str) else productos_csv)
-                
+
             outer.writestr(nested_name, nested_buf.getvalue())
 
     return outer_buf.getvalue()

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -16,11 +16,12 @@ class TestSEPAExtractor:
         # but in SEPAExtractor, `extract_zip` actually assumes the input zip CONTAINS the CSVs.
         # Wait, let me check extractor.py:
         # extract_zip expects the nested zip (with comercio.csv, sucursales.csv, productos.csv).
-        
+
         # We need to build a single nested zip bytes:
-        import zipfile, io
+        import zipfile
+        import io
         from .factories import make_comercio_df, make_sucursales_df, make_productos_df, _write_csv_with_footer
-        
+
         nested_buf = io.BytesIO()
         with zipfile.ZipFile(nested_buf, "w") as nested:
             nested.writestr("comercio.csv", _write_csv_with_footer(make_comercio_df(1), False, "2026-01-15"))
@@ -28,51 +29,53 @@ class TestSEPAExtractor:
             nested.writestr("sucursales.csv", s_csv.encode("utf-8") if isinstance(s_csv, str) else s_csv)
             p_csv = make_productos_df(10).write_csv()
             nested.writestr("productos.csv", p_csv.encode("utf-8") if isinstance(p_csv, str) else p_csv)
-            
+
         nested_zip_path = tmp_path / "nested_comercio.zip"
         nested_zip_path.write_bytes(nested_buf.getvalue())
-        
+
         extract_to = tmp_path / "extracted"
         csv_paths, date_status = SEPAExtractor.extract_zip(nested_zip_path, extract_to)
-        
+
         assert "comercio" in csv_paths
         assert "sucursales" in csv_paths
         assert "productos" in csv_paths
-        
+
         assert csv_paths["comercio"].exists()
         assert csv_paths["sucursales"].exists()
         assert csv_paths["productos"].exists()
 
     def test_extract_zip_missing_files(self, tmp_path: Path):
         """Test extraction fails when expected CSVs are missing."""
-        import zipfile, io
-        
+        import zipfile
+        import io
+
         nested_buf = io.BytesIO()
         with zipfile.ZipFile(nested_buf, "w") as nested:
             nested.writestr("sucursales.csv", "id_sucursal\n1")
-            
+
         nested_zip_path = tmp_path / "nested_missing.zip"
         nested_zip_path.write_bytes(nested_buf.getvalue())
-        
+
         extract_to = tmp_path / "extracted"
         with pytest.raises(ValueError, match="missing files"):
             SEPAExtractor.extract_zip(nested_zip_path, extract_to)
 
     def test_extract_all_zips(self, tmp_path: Path):
         """Test extract_all_zips correctly processes valid and malformed zips."""
-        import zipfile, io
+        import zipfile
+        import io
         from datetime import date
-        
+
         source_dir = tmp_path
         target_date = date(2026, 1, 15)
         # We need the zip files inside the date directory
         date_dir = source_dir / target_date.isoformat()
         date_dir.mkdir()
-        
+
         zip1_path = date_dir / "sepa_1.zip"
         zip2_path = date_dir / "sepa_2.zip"
         zip3_path = date_dir / "sepa_3.zip"  # malformed
-        
+
         # Valid nested zip
         nested_buf = io.BytesIO()
         with zipfile.ZipFile(nested_buf, "w") as nested:
@@ -82,14 +85,14 @@ class TestSEPAExtractor:
             nested.writestr("sucursales.csv", s_csv.encode("utf-8") if isinstance(s_csv, str) else s_csv)
             p_csv = make_productos_df(10).write_csv()
             nested.writestr("productos.csv", p_csv.encode("utf-8") if isinstance(p_csv, str) else p_csv)
-            
+
         zip1_path.write_bytes(nested_buf.getvalue())
         zip2_path.write_bytes(nested_buf.getvalue())
         zip3_path.write_bytes(b"PK\x05\x06not a real zip")
-        
+
         # Test extraction
         all_csv_paths, malformed_count, stale_count, unknown_count = SEPAExtractor.extract_all_zips(source_dir, target_date)
-        
+
         assert len(all_csv_paths) == 2
         assert malformed_count == 1
         assert "comercio" in all_csv_paths[0]

--- a/tests/test_loader_buffer.py
+++ b/tests/test_loader_buffer.py
@@ -1,0 +1,113 @@
+"""Tests for silver precios append buffering (fewer, larger Iceberg data files)."""
+
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import polars as pl
+
+from sepa_pipeline.loaders.bigquery_loader import BigQueryLoader
+from sepa_pipeline.loaders.iceberg_loader import IcebergLoader
+
+
+FECHA = date(2026, 7, 10)
+
+
+def _precios_df(n: int, start: int = 0) -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "id_comercio": [str(i) for i in range(start, start + n)],
+            "id_bandera": ["1"] * n,
+            "id_sucursal": ["1"] * n,
+            "id_producto": [f"SKU{i}" for i in range(start, start + n)],
+            "precio_lista": [100.0] * n,
+        }
+    )
+
+
+def _make_iceberg_loader(target_rows: int = 1000) -> IcebergLoader:
+    loader = IcebergLoader.__new__(IcebergLoader)
+    loader.config = SimpleNamespace()
+    loader.stage_name = "IcebergLoader"
+    loader.catalog = object()
+    loader._iceberg_table = MagicMock()
+    loader._dim_tables = {}
+    loader._seen_productos = set()
+    loader._precios_buffer = []
+    loader._precios_buffer_rows = 0
+    loader._precios_append_target_rows = target_rows
+    loader._productos_buffer = []
+    return loader
+
+
+def _make_bq_loader(target_rows: int = 1000) -> BigQueryLoader:
+    loader = BigQueryLoader.__new__(BigQueryLoader)
+    loader.config = SimpleNamespace()
+    loader.stage_name = "BigQueryLoader"
+    loader.catalog = object()
+    loader._iceberg_table = MagicMock()
+    loader._dim_tables = {}
+    loader._seen_productos = set()
+    loader._namespace = "silver"
+    loader._precios_buffer = []
+    loader._precios_buffer_rows = 0
+    loader._precios_append_target_rows = target_rows
+    loader._productos_buffer = []
+    return loader
+
+
+def test_iceberg_buffers_until_target_then_appends() -> None:
+    loader = _make_iceberg_loader(target_rows=1000)
+    append_sizes: list[int] = []
+
+    def capture(df: pl.DataFrame, fecha_vigencia: date) -> None:
+        append_sizes.append(len(df))
+
+    loader._append_precios = capture  # type: ignore[method-assign]
+
+    loader.load(_precios_df(600), FECHA)
+    assert append_sizes == []
+    assert loader._precios_buffer_rows == 600
+
+    loader.load(_precios_df(500, start=600), FECHA)
+    # 600 + 500 >= 1000 → one flush
+    assert append_sizes == [1100]
+    assert loader._precios_buffer_rows == 0
+
+
+def test_iceberg_flush_writes_remainder() -> None:
+    loader = _make_iceberg_loader(target_rows=10_000)
+    append_sizes: list[int] = []
+    loader._append_precios = (  # type: ignore[method-assign]
+        lambda df, fecha: append_sizes.append(len(df))
+    )
+
+    loader.load(_precios_df(100), FECHA)
+    loader.load(_precios_df(50, start=100), FECHA)
+    assert append_sizes == []
+
+    loader.flush(FECHA)
+    assert append_sizes == [150]
+    assert loader._precios_buffer_rows == 0
+
+    # Second flush is a no-op
+    loader.flush(FECHA)
+    assert append_sizes == [150]
+
+
+def test_bigquery_buffer_mirrors_iceberg() -> None:
+    loader = _make_bq_loader(target_rows=100)
+    append_sizes: list[int] = []
+    loader._append_precios = (  # type: ignore[method-assign]
+        lambda df, fecha: append_sizes.append(len(df))
+    )
+
+    loader.load(_precios_df(40), FECHA)
+    loader.load(_precios_df(40, start=40), FECHA)
+    assert append_sizes == []
+    loader.load(_precios_df(40, start=80), FECHA)
+    assert append_sizes == [120]
+    loader.flush(FECHA)
+    assert append_sizes == [120]

--- a/tests/test_parquet_loader.py
+++ b/tests/test_parquet_loader.py
@@ -79,6 +79,39 @@ def test_exists_false_when_empty(loader: ParquetLoader) -> None:
     assert loader.exists(FECHA) is False
 
 
+def _multi_child_csv_paths(tmp_path: Path) -> list[dict[str, Path]]:
+    """Two child ZIPs so streamed write covers multi-batch ParquetWriter path."""
+    paths = _sample_csv_paths(tmp_path)
+    base = tmp_path / "extract" / "child2"
+    comercio = base / "comercio.csv"
+    sucursales = base / "sucursales.csv"
+    productos = base / "productos.csv"
+    _write_csv(
+        comercio,
+        "id_comercio|comercio_cuit|comercio_razon_social",
+        "2|20999888777|Other SA",
+    )
+    _write_csv(
+        sucursales,
+        "id_comercio|id_bandera|id_sucursal|sucursales_nombre",
+        "2|1|20|Sucursal Norte",
+    )
+    _write_csv(
+        productos,
+        "id_comercio|id_bandera|id_sucursal|id_producto|productos_ean|"
+        "productos_descripcion|productos_precio_lista",
+        "2|1|20|SKU9|7790009|Yerba|2100.00",
+    )
+    paths.append(
+        {
+            "comercio": comercio,
+            "sucursales": sucursales,
+            "productos": productos,
+        }
+    )
+    return paths
+
+
 def test_build_commits_and_exists(
     loader: ParquetLoader,
     local_fs: fs.SubTreeFileSystem,
@@ -104,6 +137,23 @@ def test_build_commits_and_exists(
 
     productos = list(loader.read_productos_batched(FECHA, batch_size=1))
     assert sum(df.height for df in productos) == 2
+
+
+def test_streamed_build_merges_multiple_child_zips(
+    loader: ParquetLoader,
+    tmp_path: Path,
+) -> None:
+    """Streaming writer still produces one unified parquet per table."""
+    audit = loader.build(_multi_child_csv_paths(tmp_path), FECHA)
+
+    assert loader.exists(FECHA) is True
+    assert audit["comercio"]["parquet_rows"] == 2
+    assert audit["sucursales"]["parquet_rows"] == 2
+    assert audit["productos"]["parquet_rows"] == 3
+
+    dims = loader.read_dimensions(FECHA)
+    assert dims["comercio"].height == 2
+    assert sum(df.height for df in loader.read_productos_batched(FECHA)) == 3
 
 
 def test_exists_requires_success_marker(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -22,9 +22,9 @@ class TestSchemaTransforms:
             "productos_precio_lista": ["100.5"],
             "extra_column": ["drop_me"]
         })
-        
+
         df_silver = to_silver_precios(df_raw)
-        
+
         assert "extra_column" not in df_silver.columns
         assert df_silver["ean"][0] is True
         assert df_silver["precio_lista"][0] == 100.5
@@ -38,9 +38,9 @@ class TestSchemaTransforms:
             "id_sucursal": ["1"],
             "sucursales_provincia": ["Buenos Aires"]
         })
-        
+
         df_silver = to_silver_sucursales(df_raw)
-        
+
         assert df_silver["provincia"][0] == "AR-B"
 
     def test_to_silver_productos_marca_null_fill(self):
@@ -53,16 +53,16 @@ class TestSchemaTransforms:
             "productos_cantidad_presentacion": ["1.0", "2.0"],
             "productos_unidad_medida_presentacion": ["kg", "kg"]
         })
-        
+
         df_silver = to_silver_productos(df_raw)
-        
+
         assert df_silver["marca"][0] == "Marca A"
         assert df_silver["marca"][1] == "S/D"
 
     def test_get_schema_dict_invalid(self):
         with pytest.raises(ValueError, match="Unknown table type"):
             get_schema_dict("invalid_table")
-            
+
     def test_get_silver_schema_dict_invalid(self):
         with pytest.raises(ValueError, match="Unknown Silver table"):
             get_silver_schema_dict("invalid_table")

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -365,12 +365,12 @@ class TestSepaScraper:
     async def test_validate_zip_date_consensus_valid(self, sample_url, sample_data_dir):
         """Test consensus logic with a predominantly valid ZIP."""
         from .factories import make_sepa_zip
-        
+
         async with SepaScraper(url=sample_url, data_dir=str(sample_data_dir), target_date="2026-01-15") as scraper:
             zip_bytes = make_sepa_zip(target_date="2026-01-15", n_nested_zips=3, stale_majority=False)
             zip_path = sample_data_dir / "sepa_valid_consensus.zip"
             zip_path.write_bytes(zip_bytes)
-            
+
             result = scraper._validate_zip_date(zip_path)
             assert result is True
 
@@ -378,13 +378,13 @@ class TestSepaScraper:
     async def test_validate_zip_date_consensus_stale(self, sample_url, sample_data_dir):
         """Test consensus logic with a predominantly stale ZIP."""
         from .factories import make_sepa_zip
-        
+
         async with SepaScraper(url=sample_url, data_dir=str(sample_data_dir), target_date="2026-01-15") as scraper:
             # Build a ZIP where the majority of nested ZIPs have stale dates
             zip_bytes = make_sepa_zip(target_date="2026-01-15", n_nested_zips=5, stale_majority=True)
             zip_path = sample_data_dir / "sepa_stale_consensus.zip"
             zip_path.write_bytes(zip_bytes)
-            
+
             result = scraper._validate_zip_date(zip_path)
             assert result is False
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,8 +1,5 @@
-import pytest
 import polars as pl
-from pathlib import Path
 from sepa_pipeline.validator import SEPAValidator
-from .factories import make_comercio_df, make_sucursales_df, make_productos_df
 
 class TestSEPAValidator:
 
@@ -19,7 +16,7 @@ class TestSEPAValidator:
             "comercio_ultima_actualizacion": ["U"],
             "comercio_version_sepa": ["1"]
         })
-        
+
         cleaned = validator.validate_comercio(df)
         assert cleaned["id_bandera"].dtype == pl.Int32
         assert cleaned["comercio_cuit"].dtype == pl.Int64
@@ -45,40 +42,40 @@ class TestSEPAValidator:
             "productos_precio_unitario_promo2": ["", ""],
             "productos_leyenda_promo2": ["", ""]
         })
-        
+
         cleaned = validator.validate_productos(df)
         assert cleaned.height == 1
         assert cleaned["id_producto"][0] == 100
 
     def test_validate_referential_integrity(self):
         validator = SEPAValidator()
-        
+
         df_comercios = pl.DataFrame({
             "id_comercio": ["1"],
             "id_bandera": [1]
         })
-        
+
         df_sucursales = pl.DataFrame({
             "id_comercio": ["1", "2"], # "2" is orphaned
             "id_bandera": [1, 1],
             "id_sucursal": [10, 20]
         })
-        
+
         df_productos = pl.DataFrame({
             "id_comercio": ["1", "1"],
             "id_bandera": [1, 1],
             "id_sucursal": [10, 99], # "99" is orphaned
             "id_producto": [100, 200]
         })
-        
+
         clean_sucursales, clean_productos = validator.validate_referential_integrity(
             df_comercios, df_sucursales, df_productos
         )
-        
+
         # Orphaned sucursal should be dropped
         assert clean_sucursales.height == 1
         assert clean_sucursales["id_comercio"][0] == "1"
-        
+
         # Orphaned producto should be dropped
         assert clean_productos.height == 1
         assert clean_productos["id_sucursal"][0] == 10


### PR DESCRIPTION
## Summary

Implements [SEP-278](https://linear.app/sepa/issue/SEP-278): lower bronze materialization memory pressure and reduce silver Iceberg small-file fanout.

### Bronze (streamed stage, still one file per table)

- `ParquetLoader.build()` stages via `ParquetWriter`: each child-ZIP CSV is read, written as a row group, then freed (no full-day `pl.concat` of ~12M productos rows).
- Still produces a **single** `comercio` / `sucursales` / `productos` parquet per day after atomic commit (`.staging/` → final + `_SUCCESS` from SEP-277).
- Audit row counts remain correct (`csv_rows` / `parquet_rows` from the stream).

### Silver (fewer, larger fact appends & unified dimension writes)

- Validation path still streams bronze in **500k** batches (unchanged, intentional).
- `IcebergLoader` / `BigQueryLoader` **buffer** `precios` until ~**2M** rows (`PRECIOS_APPEND_TARGET_ROWS`), then append once; `flush()` at end of day writes the remainder.
- Result for `precios`: multi-million-row Iceberg appends instead of ~24× ~500k appends per day.
- Result for `dim_productos`: completely buffered across validation chunks and committed atomically upon `flush()`, drastically reducing small-parquet fanout from ~17 down to ~5 files.

### Docs / tests

- `AGENTS.md` notes the two batching layers.
- Tests: multi-child streamed bronze merge; buffer target / flush behavior for Iceberg + BQ loaders.

## Live check (2026-07-11)

- Bronze: `Staging productos.parquet (streamed): 11,949,545 rows from 17 CSV(s)` + commit + `_SUCCESS`.
- Silver: still logs `batches of 500,000` for read/validate; Iceberg appends ~2.0–2.4M rows when buffer flushes.
- Peak RSS still on the order of several GB during large appends (buffer + `concat` + `to_arrow`); further RAM vs file-size tuning can lower `PRECIOS_APPEND_TARGET_ROWS` or use a disk-backed buffer later.

## Live check (2026-07-12 - dim_productos buffering)

- `dim_productos` parquet files on MinIO were successfully reduced from 17 down to 5.
- Peak RAM usage remains stable at ~5 GB.
- Full pipeline run successful with ~11.97M rows processed and integrity validation successfully filtering 87k missing sucursales rows.

## Out of scope

- Silver cache / `--force-rebuild-silver` (follow-up)
- Snapshot expiry / physical file GC with Nessie ([SEP-274](https://linear.app/sepa/issue/SEP-274), [SEP-268](https://linear.app/sepa/issue/SEP-268))

## Test plan

- [x] `uv run pytest tests/ -v` (incl. `test_parquet_loader`, `test_loader_buffer`)
- [x] Live: `--date 2026-07-11 --target iceberg --force-rebuild-bronze`
- [x] Confirm MinIO bronze day has one `productos.parquet` + `_SUCCESS`
- [x] Confirm Iceberg logs multi-million-row appends (not only ~500k)
