### PR TITLE
[SEP-290] align dbt models with silver schema

### DIFF
--- a/dbt/sepa_analytics/models/gold/gold_cross_price_elasticity.sql
+++ b/dbt/sepa_analytics/models/gold/gold_cross_price_elasticity.sql
@@ -22,15 +22,13 @@ WITH chain_avg_prices AS (
     SELECT
         p.fecha_vigencia,
         p.id_producto,
-        {{ clean_description('d.descripcion') }} AS descripcion_clean,
-        d.marca,
+        {{ clean_description('p.descripcion') }} AS descripcion_clean,
+        p.marca,
         c.bandera_nombre AS cadena,
         AVG(p.precio_lista) AS precio_promedio,
         COUNT(*) AS num_observaciones
-    FROM {{ ref('stg_precios') }} p
-    LEFT JOIN {{ ref('stg_dim_productos') }} d
-        ON p.id_producto = d.id_producto
-    LEFT JOIN {{ ref('stg_dim_comercios') }} c
+    FROM {{ ref('fct_price_quotes') }} p
+    LEFT JOIN {{ ref('dim_comercios_current') }} c
         ON p.id_comercio = c.id_comercio
         AND p.id_bandera = c.id_bandera
     WHERE p.precio_lista >= 10.0

--- a/dbt/sepa_analytics/models/gold/gold_price_hypothesis.sql
+++ b/dbt/sepa_analytics/models/gold/gold_price_hypothesis.sql
@@ -23,9 +23,9 @@ SELECT
     p.id_sucursal,
 
     -- Product info (cleaned)
-    {{ clean_description('d.descripcion') }} AS descripcion_clean,
-    d.marca,
-    {{ categorize_product(clean_description('d.descripcion')) }} AS categoria_inferida,
+    {{ clean_description('p.descripcion') }} AS descripcion_clean,
+    p.marca,
+    {{ categorize_product(clean_description('p.descripcion')) }} AS categoria_inferida,
 
     -- Chain info
     c.bandera_nombre,
@@ -39,13 +39,11 @@ SELECT
     CASE WHEN p.precio_unitario_promo1 IS NOT NULL THEN true ELSE false END AS tiene_promo,
     COALESCE(p.precio_unitario_promo1, p.precio_lista) AS precio_efectivo
 
-FROM {{ ref('stg_precios') }} p
-LEFT JOIN {{ ref('stg_dim_productos') }} d
-    ON p.id_producto = d.id_producto
-LEFT JOIN {{ ref('stg_dim_sucursales') }} s
+FROM {{ ref('fct_price_quotes') }} p
+LEFT JOIN {{ ref('dim_sucursales_current') }} s
     ON p.id_sucursal = s.id_sucursal
     AND p.id_comercio = s.id_comercio
-LEFT JOIN {{ ref('stg_dim_comercios') }} c
+LEFT JOIN {{ ref('dim_comercios_current') }} c
     ON p.id_comercio = c.id_comercio
     AND p.id_bandera = c.id_bandera
 WHERE p.precio_lista >= 10.0

--- a/dbt/sepa_analytics/models/intermediate/dim_comercios_current.sql
+++ b/dbt/sepa_analytics/models/intermediate/dim_comercios_current.sql
@@ -9,17 +9,14 @@
 #}
 
 SELECT
-    CAST(id_comercio AS STRING) AS id_comercio,
-    CAST(id_bandera AS STRING) AS id_bandera,
-    comercio_cuit AS cuit,
-    comercio_razon_social AS razon_social,
-    comercio_bandera_nombre AS bandera_nombre,
-    comercio_bandera_url AS bandera_url,
-    comercio_version_sepa AS version_sepa,
-    comercio_ultima_actualizacion AS ultima_actualizacion
-FROM {{ iceberg_source('dim_comercios') }}
-{% if target.type == 'duckdb' %}
-    QUALIFY ROW_NUMBER() OVER (PARTITION BY id_comercio, id_bandera ORDER BY fecha_vigencia_day DESC) = 1
-{% else %}
-    QUALIFY ROW_NUMBER() OVER (PARTITION BY id_comercio, id_bandera ORDER BY fecha_vigencia DESC) = 1
-{% endif %}
+    id_comercio,
+    id_bandera,
+    cuit,
+    razon_social,
+    bandera_nombre,
+    bandera_url
+FROM {{ ref('stg_dim_comercios') }}
+QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY id_comercio, id_bandera
+    ORDER BY fecha_vigencia DESC
+) = 1

--- a/dbt/sepa_analytics/models/intermediate/dim_productos_current.sql
+++ b/dbt/sepa_analytics/models/intermediate/dim_productos_current.sql
@@ -11,23 +11,14 @@
 #}
 
 SELECT
-    CAST(id_producto AS STRING) AS id_producto,
-    CAST(id_comercio AS STRING) AS id_comercio,
-    CAST(id_bandera AS STRING) AS id_bandera,
-    CAST(id_sucursal AS STRING) AS id_sucursal,
-    productos_ean AS ean,
-    productos_descripcion AS descripcion,
-    productos_marca AS marca,
-    productos_cantidad_presentacion AS cantidad_presentacion,
-    productos_unidad_medida_presentacion AS unidad_medida_presentacion,
-    productos_precio_referencia AS precio_referencia,
-    productos_cantidad_referencia AS cantidad_referencia,
-    productos_unidad_medida_referencia AS unidad_medida_referencia,
-    productos_leyenda_promo1 AS leyenda_promo1,
-    productos_leyenda_promo2 AS leyenda_promo2
-FROM {{ iceberg_source('dim_productos') }}
-{% if target.type == 'duckdb' %}
-    QUALIFY ROW_NUMBER() OVER (PARTITION BY id_producto ORDER BY fecha_vigencia_day DESC) = 1
-{% else %}
-    QUALIFY ROW_NUMBER() OVER (PARTITION BY id_producto ORDER BY fecha_vigencia DESC) = 1
-{% endif %}
+    id_producto,
+    ean,
+    descripcion,
+    marca,
+    cantidad_presentacion,
+    unidad_medida_presentacion
+FROM {{ ref('stg_dim_productos') }}
+QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY id_producto
+    ORDER BY fecha_vigencia DESC
+) = 1

--- a/dbt/sepa_analytics/models/intermediate/dim_sucursales_current.sql
+++ b/dbt/sepa_analytics/models/intermediate/dim_sucursales_current.sql
@@ -10,30 +10,21 @@
 #}
 
 SELECT
-    CAST(id_sucursal AS STRING) AS id_sucursal,
-    CAST(id_comercio AS STRING) AS id_comercio,
-    CAST(id_bandera AS STRING) AS id_bandera,
-    sucursales_nombre AS nombre,
-    sucursales_tipo AS tipo,
-    sucursales_observaciones AS observaciones,
-    sucursales_calle AS calle,
-    sucursales_numero AS numero,
-    sucursales_barrio AS barrio,
-    sucursales_codigo_postal AS codigo_postal,
-    sucursales_localidad AS localidad,
-    sucursales_provincia AS provincia,
-    CAST(sucursales_latitud AS {{ dbt.type_float() }}) AS latitud,
-    CAST(sucursales_longitud AS {{ dbt.type_float() }}) AS longitud,
-    sucursales_lunes_horario_atencion AS horario_lunes,
-    sucursales_martes_horario_atencion AS horario_martes,
-    sucursales_miercoles_horario_atencion AS horario_miercoles,
-    sucursales_jueves_horario_atencion AS horario_jueves,
-    sucursales_viernes_horario_atencion AS horario_viernes,
-    sucursales_sabado_horario_atencion AS horario_sabado,
-    sucursales_domingo_horario_atencion AS horario_domingo
-FROM {{ iceberg_source('dim_sucursales') }}
-{% if target.type == 'duckdb' %}
-    QUALIFY ROW_NUMBER() OVER (PARTITION BY id_sucursal, id_comercio ORDER BY fecha_vigencia_day DESC) = 1
-{% else %}
-    QUALIFY ROW_NUMBER() OVER (PARTITION BY id_sucursal, id_comercio ORDER BY fecha_vigencia DESC) = 1
-{% endif %}
+    id_sucursal,
+    id_comercio,
+    id_bandera,
+    nombre,
+    tipo,
+    calle,
+    numero,
+    barrio,
+    codigo_postal,
+    localidad,
+    provincia,
+    latitud,
+    longitud
+FROM {{ ref('stg_dim_sucursales') }}
+QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY id_sucursal, id_comercio
+    ORDER BY fecha_vigencia DESC
+) = 1

--- a/dbt/sepa_analytics/models/marts/mart_daily_price_summary.sql
+++ b/dbt/sepa_analytics/models/marts/mart_daily_price_summary.sql
@@ -12,13 +12,12 @@
 SELECT
     p.fecha_vigencia,
     p.id_producto,
-    -- Cross-adapter aggregation: ANY_VALUE (BQ) vs MIN (DuckDB)
     {% if target.type == 'bigquery' %}
-        ANY_VALUE(d.descripcion)           AS descripcion,
-        ANY_VALUE(d.marca)                 AS marca,
+        ANY_VALUE(p.descripcion)           AS descripcion,
+        ANY_VALUE(p.marca)                 AS marca,
     {% else %}
-        MIN(d.descripcion)                 AS descripcion,
-        MIN(d.marca)                       AS marca,
+        MIN(p.descripcion)                 AS descripcion,
+        MIN(p.marca)                       AS marca,
     {% endif %}
     COUNT(*)                           AS num_observaciones,
     AVG(p.precio_lista)                AS precio_promedio,
@@ -26,9 +25,7 @@ SELECT
     MAX(p.precio_lista)                AS precio_maximo,
     -- NULL means no active promotion -- the signal is intentional, not a defect.
     MIN(p.precio_unitario_promo1) AS mejor_precio_promo
-FROM {{ ref('stg_precios') }} p
-LEFT JOIN {{ ref('stg_dim_productos') }} d
-    ON p.id_producto = d.id_producto
+FROM {{ ref('fct_price_quotes') }} p
 WHERE p.precio_lista > 0
 {% if is_incremental() %}
   -- 2-day lookback window handles late-arriving data from delayed ingestion runs

--- a/dbt/sepa_analytics/models/marts/mart_store_coverage.sql
+++ b/dbt/sepa_analytics/models/marts/mart_store_coverage.sql
@@ -16,8 +16,8 @@ SELECT
     COUNT(DISTINCT p.id_comercio)  AS cadenas_activas,
     COUNT(DISTINCT p.id_producto)  AS productos_reportados,
     COUNT(p.id_producto)           AS total_precios
-FROM {{ ref('stg_precios') }} p
-LEFT JOIN {{ ref('stg_dim_sucursales') }} s
+FROM {{ ref('fct_price_quotes') }} p
+LEFT JOIN {{ ref('dim_sucursales_current') }} s
     ON p.id_sucursal = s.id_sucursal
     AND p.id_comercio = s.id_comercio
 WHERE 1=1

--- a/dbt/sepa_analytics/models/marts/marts_schema.yml
+++ b/dbt/sepa_analytics/models/marts/marts_schema.yml
@@ -6,8 +6,7 @@ models:
       Gold incremental table aggregating price metrics per product per day.
       On first run, backfills all Silver history. Subsequent daily runs append only
       new dates (is_incremental guard on fecha_vigencia). Partitioned by fecha_vigencia.
-      JOINs stg_dim_productos for descripcion and marca -- these columns are NULL on the
-      Silver precios fact (narrow fact by design) and must come from the dimension.
+      Reads fct_price_quotes; descripcion and marca come from the denormalized Silver fact.
       Filter WHERE precio_lista > 0 applied; sentinel values (0.01-0.10) may still appear
       from upstream SEPA source -- see SEP data quality notes in DOCS.md Section 6.4.
     columns:
@@ -21,11 +20,10 @@ models:
           - not_null
       - name: descripcion
         description: >
-          Product name sourced from stg_dim_productos via JOIN. 99.8% populated.
-          ~0.2% NULL for orphaned fact rows with no matching dimension entry.
+          Product name sourced from fct_price_quotes.
       - name: marca
         description: >
-          Product brand sourced from stg_dim_productos via JOIN. ~7.8% NULL.
+          Product brand sourced from fct_price_quotes. ~7.8% NULL.
           Confirmed upstream issue: these products have NULL marca in silver.dim_productos.
           Not a pipeline defect.
       - name: num_observaciones
@@ -50,7 +48,7 @@ models:
       Gold incremental table tracking geographic and commercial coverage per province per day.
       Answers: how many stores, products, and brands are actively reporting prices per province?
       On first run, backfills all Silver history. Subsequent daily runs append only new dates.
-      Partitioned by fecha_vigencia. JOINs stg_dim_sucursales for provincia.
+      Partitioned by fecha_vigencia. JOINs dim_sucursales_current for provincia.
       NULL provincia rows exist where branches did not report a province in the SEPA source.
     columns:
       - name: fecha_vigencia

--- a/dbt/sepa_analytics/models/staging/schema.yml
+++ b/dbt/sepa_analytics/models/staging/schema.yml
@@ -4,16 +4,15 @@ models:
   - name: stg_dim_comercios
     description: >
       Staging dimension for merchant chains and banners (e.g., Coto, Carrefour, Dia).
-      Sourced from silver.dim_comercios (BigLake Iceberg). Append-only daily snapshot
-      partitioned by fecha_vigencia -- the effective primary key is [id_comercio, fecha_vigencia].
-      ID columns are cast from INT64 (Silver) to STRING to satisfy the staging type contract.
+      Sourced from silver.dim_comercios. Append-only daily snapshot with fecha_vigencia,
+      but not partitioned in Iceberg. ID columns are cast to STRING for the dbt contract.
     columns:
       - name: id_comercio
-        description: "Merchant chain identifier. Cast from INT64 to STRING. Primary key (composite with fecha_vigencia in Silver)."
+        description: "Merchant chain identifier. Composite snapshot key with id_bandera and fecha_vigencia."
         tests:
           - not_null
       - name: id_bandera
-        description: "Banner/flag identifier within the chain. Cast from INT64 to STRING."
+        description: "Banner/flag identifier within the chain."
       - name: cuit
         description: "Argentine tax identifier (CUIT) for the legal entity."
       - name: razon_social
@@ -22,31 +21,24 @@ models:
         description: "Commercial banner name (e.g., 'Coto', 'Jumbo')."
       - name: bandera_url
         description: "URL of the official website for the banner."
-      - name: version_sepa
-        description: "SEPA schema version used by this merchant's data submission."
-      - name: ultima_actualizacion
-        description: "Last update timestamp reported by the merchant in their submission."
+      - name: fecha_vigencia
+        description: "Snapshot business date."
+        tests:
+          - not_null
 
   - name: stg_dim_productos
     description: >
       Staging dimension for unique products with EAN codes and descriptions.
-      Sourced from silver.dim_productos (BigLake Iceberg). Append-only daily snapshot --
-      effective primary key is [id_producto, fecha_vigencia]. 100% of rows have
-      productos_descripcion populated. ~7.8% have NULL marca -- this is an upstream SEPA
-      source issue where some merchants do not report brand. ID columns cast INT64 -> STRING.
+      Sourced from silver.dim_productos. Append-only daily snapshot with fecha_vigencia,
+      but not partitioned in Iceberg. Product price/reference fields live on stg_precios,
+      not this dimension.
     columns:
       - name: id_producto
-        description: "Product identifier (typically EAN). Cast from INT64 to STRING. Primary key (composite with fecha_vigencia in Silver)."
+        description: "Product identifier. Composite snapshot key with fecha_vigencia."
         tests:
           - not_null
-      - name: id_comercio
-        description: "Merchant chain that reported this product. Cast from INT64 to STRING."
-      - name: id_bandera
-        description: "Banner within the chain that reported this product. Cast from INT64 to STRING."
-      - name: id_sucursal
-        description: "Branch that reported this product. Cast from INT64 to STRING."
       - name: ean
-        description: "EAN barcode of the product. May differ from id_producto for weight-variable items."
+        description: "True when id_producto is a standard EAN/UPC-A code."
       - name: descripcion
         description: "Human-readable product name (e.g., 'Leche entera La Serenisima 1L'). 100% populated in Silver."
       - name: marca
@@ -55,23 +47,18 @@ models:
         description: "Numeric quantity in the standard presentation unit."
       - name: unidad_medida_presentacion
         description: "Unit of measure for the presentation (e.g., 'Kg', 'L', 'Un')."
-      - name: precio_referencia
-        description: "Reference price for unit comparison purposes."
-      - name: cantidad_referencia
-        description: "Reference quantity for unit price calculation."
-      - name: unidad_medida_referencia
-        description: "Unit of measure for the reference price (e.g., '100g', '1L')."
-      - name: leyenda_promo1
-        description: "Text description of the first active promotion if any (e.g., '2x1')."
-      - name: leyenda_promo2
-        description: "Text description of the second active promotion if any."
+      - name: fecha_vigencia
+        description: "Snapshot business date."
+        tests:
+          - not_null
 
   - name: stg_dim_sucursales
     description: >
       Staging dimension for physical store branches with geolocation and contact data.
-      Sourced from silver.dim_sucursales (BigLake Iceberg). Append-only daily snapshot.
+      Sourced from silver.dim_sucursales. Append-only daily snapshot with fecha_vigencia,
+      but not partitioned in Iceberg.
       The provincia column is critical for mart_store_coverage aggregations.
-      ID columns cast INT64 -> STRING to match the staging type contract.
+      ID columns are cast to STRING to match the staging type contract.
     columns:
       - name: id_sucursal
         description: "Branch identifier. Cast from INT64 to STRING. Primary key (composite with fecha_vigencia in Silver)."
@@ -95,14 +82,17 @@ models:
         description: "Latitude coordinate of the branch. Cast from string to FLOAT64."
       - name: longitud
         description: "Longitude coordinate of the branch. Cast from string to FLOAT64."
+      - name: fecha_vigencia
+        description: "Snapshot business date."
+        tests:
+          - not_null
 
   - name: stg_precios
     description: >
       Staging fact table for daily price snapshots. Sourced from silver.precios (BigLake Iceberg),
-      partitioned by fecha_vigencia. This is a NARROW FACT -- product attributes
-      (descripcion, marca) are intentionally excluded from the Silver fact by pipeline.py.
-      Any mart needing product names must JOIN stg_dim_productos, not read from this model.
-      All ID columns cast from INT64 to STRING. Filter WHERE precio_lista > 0 recommended
+      partitioned by fecha_vigencia. Product attributes (descripcion, marca, presentation)
+      are denormalized onto the Silver fact for analytical queries.
+      All ID columns are cast to STRING. Filter WHERE precio_lista > 0 recommended
       in marts; sentinel prices (0.01-0.10) exist in the upstream SEPA source.
     columns:
       - name: fecha_vigencia
@@ -110,7 +100,7 @@ models:
         tests:
           - not_null
       - name: id_producto
-        description: "Product identifier. Cast from INT64 to STRING. Foreign key to stg_dim_productos.id_producto."
+        description: "Product identifier. Foreign key to stg_dim_productos.id_producto."
         tests:
           - not_null
       - name: id_sucursal

--- a/dbt/sepa_analytics/models/staging/sources.yml
+++ b/dbt/sepa_analytics/models/staging/sources.yml
@@ -25,15 +25,21 @@ sources:
             description: "Foreign key to dim_comercios"
           - name: id_bandera
             description: "Brand ID within the commerce chain"
-          - name: productos_precio_lista
+          - name: ean
+            description: "True when id_producto is a standard EAN/UPC-A code"
+          - name: descripcion
+            description: "Product description denormalized onto the fact"
+          - name: marca
+            description: "Product brand denormalized onto the fact"
+          - name: precio_lista
             description: "The listed price of the product"
-          - name: productos_precio_unitario_promo1
+          - name: precio_promo1
             description: "First promotional unit price if available"
-          - name: productos_leyenda_promo1
+          - name: leyenda_promo1
             description: "First promotional text (e.g., 2x1)"
-          - name: productos_precio_unitario_promo2
+          - name: precio_promo2
             description: "Second promotional unit price if available"
-          - name: productos_leyenda_promo2
+          - name: leyenda_promo2
             description: "Second promotional text"
           - name: scraped_at
             description: "Exact timestamp the scraper collected this item"

--- a/dbt/sepa_analytics/models/staging/stg_dim_comercios.sql
+++ b/dbt/sepa_analytics/models/staging/stg_dim_comercios.sql
@@ -2,16 +2,6 @@ with source as (
     select * from {{ iceberg_source('dim_comercios') }}
 ),
 
-deduplicated as (
-    select *
-    from source
-    {% if target.type == 'duckdb' %}
-        qualify row_number() over (partition by id_comercio, id_bandera order by fecha_vigencia_day desc) = 1
-    {% else %}
-        qualify row_number() over (partition by id_comercio, id_bandera order by fecha_vigencia desc) = 1
-    {% endif %}
-),
-
 renamed as (
     select
         -- ids
@@ -19,15 +9,14 @@ renamed as (
         cast(id_bandera as string) as id_bandera,
 
         -- dimensions
-        comercio_cuit as cuit,
-        comercio_razon_social as razon_social,
-        comercio_bandera_nombre as bandera_nombre,
-        comercio_bandera_url as bandera_url,
+        cuit,
+        razon_social,
+        bandera_nombre,
+        bandera_url,
 
-        -- metadata
-        comercio_version_sepa as version_sepa,
-        comercio_ultima_actualizacion as ultima_actualizacion
-    from deduplicated
+        -- snapshot date
+        cast(fecha_vigencia as date) as fecha_vigencia
+    from source
 )
 
 select * from renamed

--- a/dbt/sepa_analytics/models/staging/stg_dim_productos.sql
+++ b/dbt/sepa_analytics/models/staging/stg_dim_productos.sql
@@ -2,17 +2,7 @@ with source as (
     select *
     from {{ iceberg_source('dim_productos') }}
     {% if target.type == 'duckdb' and var('dev_date_filter', false) %}
-        WHERE fecha_vigencia_day >= CURRENT_DATE - INTERVAL '{{ var("dev_days_back", 5) }}' DAY
-    {% endif %}
-),
-
-deduplicated as (
-    select *
-    from source
-    {% if target.type == 'duckdb' %}
-        qualify row_number() over (partition by id_producto order by fecha_vigencia_day desc) = 1
-    {% else %}
-        qualify row_number() over (partition by id_producto order by fecha_vigencia desc) = 1
+        where fecha_vigencia >= CURRENT_DATE - INTERVAL '{{ var("dev_days_back", 5) }}' DAY
     {% endif %}
 ),
 
@@ -20,28 +10,19 @@ renamed as (
     select
         -- ids
         cast(id_producto as string) as id_producto,
-        cast(id_comercio as string) as id_comercio,
-        cast(id_bandera as string) as id_bandera,
-        cast(id_sucursal as string) as id_sucursal,
 
         -- properties
-        productos_ean as ean,
-        productos_descripcion as descripcion,
-        productos_marca as marca,
+        ean,
+        descripcion,
+        marca,
 
         -- presentation details
-        productos_cantidad_presentacion as cantidad_presentacion,
-        productos_unidad_medida_presentacion as unidad_medida_presentacion,
+        cantidad_presentacion,
+        unidad_medida_presentacion,
 
-        -- reference details
-        productos_precio_referencia as precio_referencia,
-        productos_cantidad_referencia as cantidad_referencia,
-        productos_unidad_medida_referencia as unidad_medida_referencia,
-
-        -- promo descriptions
-        productos_leyenda_promo1 as leyenda_promo1,
-        productos_leyenda_promo2 as leyenda_promo2
-    from deduplicated
+        -- snapshot date
+        cast(fecha_vigencia as date) as fecha_vigencia
+    from source
 )
 
 select * from renamed

--- a/dbt/sepa_analytics/models/staging/stg_dim_sucursales.sql
+++ b/dbt/sepa_analytics/models/staging/stg_dim_sucursales.sql
@@ -2,16 +2,6 @@ with source as (
     select * from {{ iceberg_source('dim_sucursales') }}
 ),
 
-deduplicated as (
-    select *
-    from source
-    {% if target.type == 'duckdb' %}
-        qualify row_number() over (partition by id_sucursal, id_comercio order by fecha_vigencia_day desc) = 1
-    {% else %}
-        qualify row_number() over (partition by id_sucursal, id_comercio order by fecha_vigencia desc) = 1
-    {% endif %}
-),
-
 renamed as (
     select
         -- ids
@@ -20,31 +10,24 @@ renamed as (
         cast(id_bandera as string) as id_bandera,
 
         -- details
-        sucursales_nombre as nombre,
-        sucursales_tipo as tipo,
-        sucursales_observaciones as observaciones,
+        nombre,
+        tipo,
 
         -- location
-        sucursales_calle as calle,
-        sucursales_numero as numero,
-        sucursales_barrio as barrio,
-        sucursales_codigo_postal as codigo_postal,
-        sucursales_localidad as localidad,
-        sucursales_provincia as provincia,
+        calle,
+        numero,
+        barrio,
+        codigo_postal,
+        localidad,
+        provincia,
 
         -- coordinates
-        cast(sucursales_latitud as {{ dbt.type_float() }}) as latitud,
-        cast(sucursales_longitud as {{ dbt.type_float() }}) as longitud,
+        cast(latitud as {{ dbt.type_float() }}) as latitud,
+        cast(longitud as {{ dbt.type_float() }}) as longitud,
 
-        -- hours
-        sucursales_lunes_horario_atencion as horario_lunes,
-        sucursales_martes_horario_atencion as horario_martes,
-        sucursales_miercoles_horario_atencion as horario_miercoles,
-        sucursales_jueves_horario_atencion as horario_jueves,
-        sucursales_viernes_horario_atencion as horario_viernes,
-        sucursales_sabado_horario_atencion as horario_sabado,
-        sucursales_domingo_horario_atencion as horario_domingo
-    from deduplicated
+        -- snapshot date
+        cast(fecha_vigencia as date) as fecha_vigencia
+    from source
 )
 
 select * from renamed

--- a/dbt/sepa_analytics/models/staging/stg_precios.sql
+++ b/dbt/sepa_analytics/models/staging/stg_precios.sql
@@ -2,11 +2,9 @@ with source as (
     select *
     from {{ iceberg_source('precios') }}
     {% if target.type == 'duckdb' and var('dev_date_filter', false) %}
-        {# Filter directly on the Hive partition column BEFORE rename.
-           This enables DuckDB to prune parquet files at read time. #}
-        WHERE fecha_vigencia_day >= CURRENT_DATE - INTERVAL '{{ var("dev_days_back", 5) }}' DAY
+        where fecha_vigencia >= CURRENT_DATE - INTERVAL '{{ var("dev_days_back", 5) }}' DAY
     {% elif target.type != 'duckdb' %}
-        WHERE fecha_vigencia >= '{{ var("start_date") }}'
+        where fecha_vigencia >= '{{ var("start_date") }}'
     {% endif %}
 ),
 
@@ -19,34 +17,27 @@ renamed as (
         cast(id_producto as string) as id_producto,
 
         -- dimensions cached on fact (optional use)
-        productos_ean as is_ean_valid,
-        productos_descripcion as descripcion,
-        productos_marca as marca,
-        productos_cantidad_presentacion as cantidad_presentacion,
-        productos_unidad_medida_presentacion as unidad_medida_presentacion,
-        productos_precio_referencia as precio_referencia,
-        productos_cantidad_referencia as cantidad_referencia,
-        productos_unidad_medida_referencia as unidad_medida_referencia,
+        ean as is_ean_valid,
+        descripcion,
+        marca,
+        cantidad_presentacion,
+        unidad_medida_presentacion,
+        precio_referencia,
+        cantidad_referencia,
+        unidad_medida_referencia,
 
         -- fact metrics
-        cast(productos_precio_lista as {{ dbt.type_float() }}) as precio_lista,
+        cast(precio_lista as {{ dbt.type_float() }}) as precio_lista,
 
         -- promo details
-        cast(productos_precio_unitario_promo1 as {{ dbt.type_float() }}) as precio_unitario_promo1,
-        productos_leyenda_promo1 as leyenda_promo1,
-        cast(productos_precio_unitario_promo2 as {{ dbt.type_float() }}) as precio_unitario_promo2,
-        productos_leyenda_promo2 as leyenda_promo2,
+        cast(precio_promo1 as {{ dbt.type_float() }}) as precio_unitario_promo1,
+        leyenda_promo1,
+        cast(precio_promo2 as {{ dbt.type_float() }}) as precio_unitario_promo2,
+        leyenda_promo2,
 
         -- ingestion metadata
-        allow_rechunk,
         cast(scraped_at as {{ dbt.type_timestamp() }}) as scraped_at,
-
-        -- partitioning date: DuckDB Hive partition = fecha_vigencia_day, BQ = fecha_vigencia
-        {% if target.type == 'duckdb' %}
-            cast(fecha_vigencia_day as date) as fecha_vigencia
-        {% else %}
-            cast(fecha_vigencia as date) as fecha_vigencia
-        {% endif %}
+        cast(fecha_vigencia as date) as fecha_vigencia
 
     from source
 )


### PR DESCRIPTION
### Summary

  This PR brings the dbt analytical layer back in sync with the current Silver Iceberg schema. The staging models now read the clean Silver column names defined by the pipeline,
  dimensions are treated as unpartitioned append-only snapshots, and downstream analytical models avoid joining directly to snapshot staging dimensions.

  ---

  ### Staging Models

  **`dbt/sepa_analytics/models/staging/stg_precios.sql`**
  - Replaced stale `productos_*` source columns with the current clean Silver fact columns.
  - Removed `allow_rechunk` and `fecha_vigencia_day` assumptions.
  - Uses `fecha_vigencia` directly for date filtering and output.

  **`dbt/sepa_analytics/models/staging/stg_dim_*.sql`**
  - Updated comercio, sucursal, and producto staging models to match the current Silver dimension schemas.
  - Removed raw-prefixed column references such as `comercio_*`, `sucursales_*`, and `productos_*`.
  - Staging dimensions now expose append-only snapshot rows with `fecha_vigencia` instead of performing current-state deduplication.

  ---

  ### Current Dimensions

  **`dbt/sepa_analytics/models/intermediate/dim_*_current.sql`**
  - Moved latest-row deduplication into the current dimension models.
  - Rebased current dimensions on `stg_dim_*` instead of reading raw Iceberg sources directly.
  - Removed references to old Hive partition column `fecha_vigencia_day`.

  ---

  ### Marts and Gold Models

  **`mart_daily_price_summary.sql`**
  - Reads from `fct_price_quotes` and uses fact-denormalized `descripcion` / `marca`.

  **`mart_store_coverage.sql`**
  - Joins `fct_price_quotes` to `dim_sucursales_current` to avoid snapshot fanout.

  **`gold_price_hypothesis.sql` and `gold_cross_price_elasticity.sql`**
  - Use `fct_price_quotes` for price/product attributes.
  - Join current-state dimensions for geography and chain attributes.

  ---

  ### dbt Metadata

  **`schema.yml`, `sources.yml`, `marts_schema.yml`**
  - Updated source and model docs to reflect the current Silver schema.
  - Clarified that only `precios` is partitioned by `fecha_vigencia`.
  - Documented dimensions as unpartitioned append-only snapshots.

  ---

  ### Verification

  - `uv run dbt compile --project-dir dbt/sepa_analytics --profiles-dir dbt`
  - `git diff --cached --check`

